### PR TITLE
Remove boost dependency and replaced with std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 
 project(mmpr VERSION 0.1.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(MMPR_BUILD_TESTS "Force tests to build" OFF)
@@ -14,10 +16,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(MMPR_BUILD_BENCHMARK ON)
     set(MMPR_BUILD_EXAMPLES ON)
 endif()
-
-# Add Boost (target Boost::boost)
-set(MIN_BOOST_VERSION 1.71)
-find_package(Boost ${MIN_BOOST_VERSION} REQUIRED COMPONENTS filesystem program_options)
 
 # Add Zstd compression library
 set(MIN_ZSTD_VERSION 1.4)
@@ -50,7 +48,7 @@ target_include_directories(mmpr
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(mmpr PRIVATE cxx_std_11)
+target_compile_features(mmpr PRIVATE cxx_std_17)
 target_compile_options(mmpr PRIVATE -static-libstdc++ -Wall -Wextra -pedantic)
 if((CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
     # If compiling as stand-alone project in debug mode set debug flag
@@ -58,8 +56,6 @@ if((CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND (CMAKE_BUILD_TYPE ST
 endif()
 
 target_link_libraries(mmpr
-    PUBLIC
-        Boost::filesystem
     PRIVATE
         ZSTD::ZSTD
 )

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ cmake --build . --target mmpr example-simple -- -j 4
 
 The following libraries need to be installed in the build environment:
 
-- Boost (with filesystem module), tested with v1.71
 - Zstd compression library (https://github.com/facebook/zstd), tested with v1.5.2
 
 ## Tests
@@ -83,3 +82,9 @@ If you find yourself doing this often, there are probably better options than ru
 approaches allow you to do this without root access, or by using a GUI, etc. The Arch
 Wiki [Cpu frequency scaling](https://wiki.archlinux.org/title/CPU_frequency_scaling) page is a good place to start
 looking for options.
+
+## Docker
+```shell
+cd docker/
+docker build -t debian11-zstd-develop .
+```

--- a/cmake/mmprConfig.cmake.in
+++ b/cmake/mmprConfig.cmake.in
@@ -6,8 +6,6 @@ list(APPEND CMAKE_MODULE_PATH ${MMPR_CMAKE_DIR})
 find_dependency(ZSTD @MIN_ZSTD_VERSION@)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
-find_dependency(boost_filesystem @MIN_BOOST_VERSION@)
-
 if(NOT TARGET mmpr::mmpr)
     include("${MMPR_CMAKE_DIR}/mmprTargets.cmake")
 endif()

--- a/cmake/mmprTargets.cmake
+++ b/cmake/mmprTargets.cmake
@@ -1,5 +1,5 @@
 add_library(mmpr::mmpr STATIC IMPORTED)
 set_target_properties(mmpr::mmpr PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
-    INTERFACE_LINK_LIBRARIES "Boost::boost;ZSTD::ZSTD;\$<LINK_ONLY:Boost::filesystem>"
+    INTERFACE_LINK_LIBRARIES "ZSTD::ZSTD"
 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
 FROM debian:bullseye
 LABEL description="Container for C/C++ development under Debian 11 (bullseye) + ZSTD"
-RUN apt-get update && apt-get install -y build-essential cmake gdb libzstd-dev
+RUN apt-get update && apt-get install -y build-essential cmake gdb libzstd-dev git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:bullseye
+LABEL description="Container for C/C++ development under Debian 11 (bullseye) + ZSTD"
+RUN apt-get update && apt-get install -y build-essential cmake gdb libzstd-dev

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,4 +14,4 @@ add_executable(mmpr_example_pcap_simple pcap_simple.cpp)
 target_link_libraries(mmpr_example_pcap_simple PRIVATE mmpr)
 
 add_executable(mmpr_statistics_cli statistics_cli.cpp)
-target_link_libraries(mmpr_statistics_cli PRIVATE mmpr Boost::program_options)
+target_link_libraries(mmpr_statistics_cli PRIVATE mmpr)

--- a/examples/statistics_cli.cpp
+++ b/examples/statistics_cli.cpp
@@ -1,31 +1,31 @@
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <iostream>
 #include <mmpr/pcapng/MMPcapNgReader.h>
 
 using namespace std;
 using namespace std::chrono;
-namespace po = boost::program_options;
 
 int main(int argc, char** argv) {
     vector<string> pcapFiles;
 
-    po::options_description desc("MMPR CLI options");
-    desc.add_options()("help", "produce help message");
-    desc.add_options()("input", po::value<vector<string>>(&pcapFiles)->multitoken(),
-                       "one or more files as input");
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (pcapFiles.size() <= 0) {
-        cout << "Error: you have to provide at least one input file!" << endl;
-        cout << desc << "\n";
-        return 1;
-    }
-
-    // sort files for deterministic results
-    std::sort(pcapFiles.begin(), pcapFiles.end());
+    // TODO implement without boost program options
+    //
+    //    po::options_description desc("MMPR CLI options");
+    //    desc.add_options()("help", "produce help message");
+    //    desc.add_options()("input", po::value<vector<string>>(&pcapFiles)->multitoken(),
+    //                       "one or more files as input");
+    //    po::variables_map vm;
+    //    po::store(po::parse_command_line(argc, argv, desc), vm);
+    //    po::notify(vm);
+    //
+    //    if (pcapFiles.size() <= 0) {
+    //        cout << "Error: you have to provide at least one input file!" << endl;
+    //        cout << desc << "\n";
+    //        return 1;
+    //    }
+    //
+    //    // sort files for deterministic results
+    //    std::sort(pcapFiles.begin(), pcapFiles.end());
 
     // metrics to count
     uint64_t packets = 0;
@@ -60,8 +60,8 @@ int main(int argc, char** argv) {
     cout << "Bytes: " << bytes << endl;
     cout << "Bytes (captured): " << capturedBytes << endl;
 
-    cout << (double) packets * 1000000000 / duration << " packets/s" << endl;
-    cout << (double) totalFileSize * 1000000000 / duration << " bytes/s" << endl;
+    cout << (double)packets * 1000000000 / duration << " packets/s" << endl;
+    cout << (double)totalFileSize * 1000000000 / duration << " bytes/s" << endl;
 
     return 0;
 }

--- a/examples/statistics_cli.cpp
+++ b/examples/statistics_cli.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <mmpr/pcapng/MMPcapNgReader.h>
@@ -8,24 +9,17 @@ using namespace std::chrono;
 int main(int argc, char** argv) {
     vector<string> pcapFiles;
 
-    // TODO implement without boost program options
-    //
-    //    po::options_description desc("MMPR CLI options");
-    //    desc.add_options()("help", "produce help message");
-    //    desc.add_options()("input", po::value<vector<string>>(&pcapFiles)->multitoken(),
-    //                       "one or more files as input");
-    //    po::variables_map vm;
-    //    po::store(po::parse_command_line(argc, argv, desc), vm);
-    //    po::notify(vm);
-    //
-    //    if (pcapFiles.size() <= 0) {
-    //        cout << "Error: you have to provide at least one input file!" << endl;
-    //        cout << desc << "\n";
-    //        return 1;
-    //    }
-    //
-    //    // sort files for deterministic results
-    //    std::sort(pcapFiles.begin(), pcapFiles.end());
+    for (size_t i = 1; i < argc; ++i) {
+        pcapFiles.emplace_back(argv[i]);
+    }
+
+    if (pcapFiles.size() <= 0) {
+        cout << "Error: you have to provide at least one input file!" << endl;
+        return EXIT_FAILURE;
+    }
+
+    // sort files for deterministic results
+    std::sort(pcapFiles.begin(), pcapFiles.end());
 
     // metrics to count
     uint64_t packets = 0;

--- a/include/mmpr/mmpr.h
+++ b/include/mmpr/mmpr.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mmpr/pcap.h>
 #include <mmpr/pcapng.h>
+#include <optional>
 #include <vector>
 
 #if DEBUG
@@ -41,16 +42,16 @@ struct Packet {
 
 struct TraceInterface {
     TraceInterface(){};
-    TraceInterface(boost::optional<std::string> name,
-                   boost::optional<std::string> description,
-                   boost::optional<std::string> filter,
-                   boost::optional<std::string> os)
+    TraceInterface(std::optional<std::string> name,
+                   std::optional<std::string> description,
+                   std::optional<std::string> filter,
+                   std::optional<std::string> os)
         : name(name), description(description), filter(filter), os(os) {}
 
-    boost::optional<std::string> name{boost::none};
-    boost::optional<std::string> description{boost::none};
-    boost::optional<std::string> filter{boost::none};
-    boost::optional<std::string> os{boost::none};
+    std::optional<std::string> name;
+    std::optional<std::string> description;
+    std::optional<std::string> filter;
+    std::optional<std::string> os;
 };
 
 class FileReader {

--- a/include/mmpr/pcap/PcapParser.h
+++ b/include/mmpr/pcap/PcapParser.h
@@ -1,7 +1,7 @@
 #ifndef MMPR_PCAPPARSER_H
 #define MMPR_PCAPPARSER_H
 
-#include <boost/algorithm/string.hpp>
+#include <algorithm>
 #include <mmpr/mmpr.h>
 
 namespace mmpr {
@@ -32,10 +32,11 @@ public:
             std::stringstream sstream;
             sstream << std::hex << magicNumber;
             std::string hex = sstream.str();
-            boost::to_upper(hex);
+            std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
             throw std::runtime_error(
                 "Expected PCAP file header to start with magic numbers 0xA1B2C3D4 or "
-                "0xA1B23C4D, but instead got: 0x" + hex);
+                "0xA1B23C4D, but instead got: 0x" +
+                hex);
         }
 
         if (magicNumber == 0xA1B2C3D4) {

--- a/include/mmpr/pcap/PcapReader.h
+++ b/include/mmpr/pcap/PcapReader.h
@@ -1,8 +1,9 @@
 #ifndef MMPR_PCAPREADER_H
 #define MMPR_PCAPREADER_H
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <mmpr/mmpr.h>
+#include <stdexcept>
 
 namespace mmpr {
 
@@ -13,9 +14,9 @@ public:
             throw std::runtime_error("Cannot read empty filepath");
         }
 
-        if (!boost::filesystem::exists(filepath)) {
+        if (!std::filesystem::exists(filepath)) {
             throw std::runtime_error("Cannot find file " +
-                                     boost::filesystem::absolute(filepath).string());
+                                     std::filesystem::absolute(filepath).string());
         }
     };
 

--- a/include/mmpr/pcapng.h
+++ b/include/mmpr/pcapng.h
@@ -1,7 +1,7 @@
 #ifndef MMPR_PCAPNG_H
 #define MMPR_PCAPNG_H
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 /**
@@ -9,7 +9,7 @@
  */
 #define MMPR_SECTION_HEADER_BLOCK 0x0A0D0D0A
 #define MMPR_INTERFACE_DESCRIPTION_BLOCK 1
-#define MMPR_PACKET_BLOCK 2  // deprecated in newer PcapNG versions
+#define MMPR_PACKET_BLOCK 2 // deprecated in newer PcapNG versions
 #define MMPR_SIMPLE_PACKET_BLOCK 3
 #define MMPR_NAME_RESOLUTION_BLOCK 4
 #define MMPR_INTERFACE_STATISTICS_BLOCK 5
@@ -68,10 +68,10 @@ struct InterfaceDescriptionBlock {
     uint32_t snapLen{0};
     struct Options {
         uint32_t timestampResolution{1000000 /* 10^6 */};
-        boost::optional<std::string> name{boost::none};
-        boost::optional<std::string> description{boost::none};
-        boost::optional<std::string> filter{boost::none};
-        boost::optional<std::string> os{boost::none};
+        std::optional<std::string> name;
+        std::optional<std::string> description;
+        std::optional<std::string> filter;
+        std::optional<std::string> os;
     } options{};
 };
 

--- a/include/mmpr/pcapng/PcapNgReader.h
+++ b/include/mmpr/pcapng/PcapNgReader.h
@@ -1,8 +1,9 @@
 #ifndef MMPR_PCAPNGREADER_H
 #define MMPR_PCAPNGREADER_H
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <mmpr/mmpr.h>
+#include <stdexcept>
 
 namespace mmpr {
 
@@ -13,9 +14,9 @@ public:
             throw std::runtime_error("Cannot read empty filepath");
         }
 
-        if (!boost::filesystem::exists(filepath)) {
+        if (!std::filesystem::exists(filepath)) {
             throw std::runtime_error("Cannot find file " +
-                                     boost::filesystem::absolute(filepath).string());
+                                     std::filesystem::absolute(filepath).string());
         }
     };
 

--- a/src/Reader.cpp
+++ b/src/Reader.cpp
@@ -1,18 +1,19 @@
 #include <mmpr/mmpr.h>
 
 #include "util.h"
+#include <filesystem>
 #include <iostream>
+#include <memory>
 #include <mmpr/pcap/MMPcapReader.h>
 #include <mmpr/pcapng/MMPcapNgReader.h>
 #include <mmpr/pcapng/ZstdPcapNgReader.h>
-#include <memory>
 
 namespace mmpr {
 
 FileReader::FileReader(const std::string& filepath) : mFilepath(filepath) {}
 
 std::unique_ptr<FileReader> FileReader::getReader(const std::string& filepath) {
-    if (!boost::filesystem::exists(filepath)) {
+    if (!std::filesystem::exists(filepath)) {
         throw std::runtime_error("FileReader: could not find file \"" + filepath + "\"");
     }
 

--- a/src/ZstdDecompressor.cpp
+++ b/src/ZstdDecompressor.cpp
@@ -1,13 +1,14 @@
 #include <mmpr/ZstdDecompressor.h>
 
-#include <boost/filesystem.hpp>
+#include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <mmpr/pcapng/PcapNgBlockParser.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #include <zstd.h>
 
 using namespace std;
-using namespace boost::filesystem;
 
 namespace mmpr {
 
@@ -15,8 +16,9 @@ void* ZstdDecompressor::decompressFileInMemory(const std::string& fname,
                                                size_t& decompressedSize) {
     int fd = ::open(fname.c_str(), O_RDONLY, 0);
     if (fd < 0) {
-        throw runtime_error("Error while reading file " + absolute(fname).string() +
-                            ": " + strerror(errno));
+        throw runtime_error("Error while reading file " +
+                            std::filesystem::absolute(fname).string() + ": " +
+                            strerror(errno));
     }
 
     size_t compressedSize = lseek(fd, 0, SEEK_END);
@@ -25,8 +27,9 @@ void* ZstdDecompressor::decompressFileInMemory(const std::string& fname,
     void* const compressedData = mmap(nullptr, mappedSize, PROT_READ, MAP_SHARED, fd, 0);
     if (compressedData == MAP_FAILED) {
         ::close(fd);
-        throw runtime_error("Error while mapping file " + absolute(fname).string() +
-                            ": " + strerror(errno));
+        throw runtime_error("Error while mapping file " +
+                            std::filesystem::absolute(fname).string() + ": " +
+                            strerror(errno));
     }
 
     /* Read the content size from the frame header. For simplicity we require

--- a/src/pcapng/ZstdPcapNgReader.cpp
+++ b/src/pcapng/ZstdPcapNgReader.cpp
@@ -1,14 +1,11 @@
 #include <mmpr/pcapng/ZstdPcapNgReader.h>
 
 #include "util.h"
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/filesystem.hpp>
+#include <algorithm>
 #include <mmpr/ZstdDecompressor.h>
 #include <sstream>
 
 using namespace std;
-using namespace boost::filesystem;
-using namespace boost::algorithm;
 
 namespace mmpr {
 
@@ -18,7 +15,7 @@ ZstdPcapNgReader::ZstdPcapNgReader(const std::string& filepath) : PcapNgReader(f
         stringstream sstream;
         sstream << std::hex << magicNumber;
         string hex = sstream.str();
-        boost::to_upper(hex);
+        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error("Expected ZSTD format to start with appropriate magic "
                                  "number, instead got: 0x" +
                                  hex + ", possibly little/big endian issue");

--- a/tests/src/testFileReader.cpp
+++ b/tests/src/testFileReader.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <mmpr/mmpr.h>
 
 TEST(FileReader, GetReader) {
-    for (auto& p : boost::filesystem::directory_iterator("tracefiles/")) {
+    for (auto& p : std::filesystem::directory_iterator("tracefiles/")) {
         auto reader = mmpr::FileReader::getReader(p.path().string());
         reader->open();
 


### PR DESCRIPTION
* Increases C++ standard to 17 (support for optionals)
* Removes boost from CMake dependencies and configs
* Replaces boost filesystem, optional and algorithm with std equivalents