### PR TITLE
Move code from headers to cpp files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(mmpr PRIVATE libzstd_static)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Visual Studio
-    target_compile_options(mmpr PRIVATE /Wall)
+    target_compile_options(mmpr PRIVATE /W4 /WX)
     add_definitions(-D_AMD64_=1) # TODO possibly there is a better way to solve the "No Target Architecture" error
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC, MinGW etc.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.16)
 project(mmpr VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # in standalone set default settings to ON
@@ -14,32 +16,28 @@ else()
     option(MMPR_BUILD_EXAMPLES "Build examples" OFF)
 endif()
 
+set(ZSTD_BUILD_STATIC ON)
+set(ZSTD_BUILD_SHARED OFF)
+set(ZSTD_LEGACY_SUPPORT OFF)
+set(ZSTD_BUILD_PROGRAMS OFF)
+set(ZSTD_BUILD_TESTS OFF)
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/libs/zstd/build/cmake")
+
 # mmpr library target
-file(GLOB_RECURSE MMPR_SRC_FILES src/*.cpp)
+file(GLOB_RECURSE MMPR_SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
 add_library(mmpr ${MMPR_SRC_FILES})
 add_library(mmpr::mmpr ALIAS mmpr)
 
+target_compile_features(mmpr PUBLIC cxx_std_17)
 target_include_directories(mmpr
     PUBLIC
         $<INSTALL_INTERFACE:include>
-        $<INSTALL_INTERFACE:include/filesystem>
-        $<INSTALL_INTERFACE:include/filesystem/writing>
-        $<INSTALL_INTERFACE:include/filesystem/reading>
-        $<INSTALL_INTERFACE:include/pcap>
-        $<INSTALL_INTERFACE:include/pcapng>
-        $<INSTALL_INTERFACE:include/modified_pcap>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/filesystem>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/filesystem/writing>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/filesystem/reading>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/pcap>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/pcapng>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/modified_pcap>
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libs/zstd/lib>
 )
+target_link_libraries(mmpr PRIVATE libzstd_static)
 
-target_compile_features(mmpr PUBLIC cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Visual Studio
     target_compile_options(mmpr PRIVATE /Wall)
@@ -53,14 +51,6 @@ if((CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND (CMAKE_BUILD_TYPE ST
     # If compiling as stand-alone project in debug mode set debug flag
     target_compile_options(mmpr PRIVATE -DDEBUG)
 endif()
-
-set(ZSTD_BUILD_STATIC ON)
-set(ZSTD_BUILD_SHARED OFF)
-set(ZSTD_LEGACY_SUPPORT OFF)
-set(ZSTD_BUILD_PROGRAMS OFF)
-set(ZSTD_BUILD_TESTS OFF)
-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/libs/zstd/build/cmake")
-target_link_libraries(mmpr PRIVATE libzstd_static)
 
 if(WIN32)
     # Windows requires winsock32.h for ntohs and ntohl etc.

--- a/include/mmpr/filesystem/reading/FReadFileReader.hpp
+++ b/include/mmpr/filesystem/reading/FReadFileReader.hpp
@@ -15,15 +15,7 @@ namespace mmpr {
 
 class FReadFileReader : public FileReader {
 public:
-    FReadFileReader(const std::string& filepath) : FileReader(filepath) {
-        mFileContent = std::unique_ptr<uint8_t>(new uint8_t[mFileSize]);
-        FILE* const inFile = fopen(mFilepath.c_str(), "rb");
-        if (fread(mFileContent.get(), 1, mFileSize, inFile) != mFileSize) {
-            throw std::runtime_error("fread error: " + std::string(strerror(errno)));
-        }
-        fclose(inFile);
-        mFileContentPtr = mFileContent.get();
-    }
+    FReadFileReader(const std::string& filepath);
 
     const uint8_t* data() const override { return mFileContentPtr; }
 

--- a/include/mmpr/filesystem/reading/FileReader.hpp
+++ b/include/mmpr/filesystem/reading/FileReader.hpp
@@ -9,27 +9,11 @@ namespace mmpr {
 
 class FileReader {
 public:
-    FileReader(const std::string& filepath)
-        : mFilepath(filepath), mFileSize(std::filesystem::file_size(filepath)) {
-        if (filepath.empty()) {
-            throw std::runtime_error("Cannot read empty filepath");
-        }
-
-        if (!std::filesystem::exists(filepath)) {
-            throw std::runtime_error("Cannot find file " +
-                                     std::filesystem::absolute(filepath).string());
-        }
-    }
+    FileReader(const std::string& filepath);
 
     virtual const uint8_t* data() const = 0;
 
-    std::size_t getSafeToReadSize() const {
-        if (mOffset >= mFileSize) {
-            return 0;
-        } else {
-            return mFileSize - mOffset;
-        }
-    }
+    std::size_t getSafeToReadSize() const;
 
     bool isExhausted() const { return mOffset >= mFileSize; }
 

--- a/include/mmpr/filesystem/reading/MMapFileReader.hpp
+++ b/include/mmpr/filesystem/reading/MMapFileReader.hpp
@@ -61,55 +61,7 @@ typedef std::unique_ptr<WinHandle, WinHandle::Deleter> HandlePtr;
 
 class MMapFileReader : public FileReader {
 public:
-    MMapFileReader(const std::string& filepath) : FileReader(filepath) {
-
-#if __linux__
-        mFileDescriptor = ::open(mFilepath.c_str(), O_RDONLY, 0);
-        if (mFileDescriptor < 0) {
-            throw std::runtime_error("Error while reading file " +
-                                     std::filesystem::absolute(mFilepath).string() +
-                                     ": " + strerror(errno));
-        }
-
-        auto mmapResult =
-            mmap(nullptr, mFileSize, PROT_READ, MAP_SHARED, mFileDescriptor, 0);
-        if (mmapResult == MAP_FAILED) {
-            ::close(mFileDescriptor);
-            throw std::runtime_error("Error while mapping file " +
-                                     std::filesystem::absolute(mFilepath).string() +
-                                     ": " + strerror(errno));
-        }
-
-        mOffset = 0;
-        mMappedMemory = reinterpret_cast<const uint8_t*>(mmapResult);
-#elif _WIN32
-        mFileHandle = HandlePtr(CreateFile(mFilepath.c_str(), GENERIC_READ,
-                                           /*shared mode*/ 0,
-                                           /*security*/ nullptr, OPEN_EXISTING,
-                                           FILE_ATTRIBUTE_NORMAL,
-                                           /*template*/ nullptr));
-        if (!mFileHandle) {
-            throw std::runtime_error("could not create file handle for " + mFilepath);
-        }
-
-        mFileMappingHandle = HandlePtr(CreateFileMapping(mFileHandle.get(), NULL,
-                                                         PAGE_READONLY, /*size high*/ 0,
-                                                         /*size low*/ 0, NULL));
-        if (!mFileMappingHandle) {
-            throw std::runtime_error("could not create file mapping handle for " +
-                                     mFilepath);
-        }
-
-        // map the input file
-        auto mmapResult = MapViewOfFile(mFileMappingHandle.get(), FILE_MAP_READ, 0, 0, 0);
-        if (mmapResult == nullptr) {
-            throw std::runtime_error("failed to map file to memory: " + mFilepath);
-        }
-
-        mOffset = 0;
-        mMappedMemory = reinterpret_cast<const uint8_t*>(mmapResult);
-#endif
-    }
+    MMapFileReader(const std::string& filepath);
 
     MMapFileReader(mmpr::ZstdFileReader reader);
 

--- a/include/mmpr/filesystem/reading/ZstdFileReader.hpp
+++ b/include/mmpr/filesystem/reading/ZstdFileReader.hpp
@@ -12,10 +12,7 @@ class ZstdFileReader : public FileReader {
 public:
     ZstdFileReader(const std::string& filepath);
 
-    ZstdFileReader(ZstdFileReader&& other)
-        : FileReader(other.mFilepath),
-          mDecompressedData(std::move(other.mDecompressedData)),
-          mDecompressedDataPtr(mDecompressedData.get()) {}
+    ZstdFileReader(ZstdFileReader&& other);
 
     const uint8_t* data() const override { return mDecompressedDataPtr; }
 

--- a/include/mmpr/filesystem/writing/FileWriter.hpp
+++ b/include/mmpr/filesystem/writing/FileWriter.hpp
@@ -10,6 +10,7 @@ namespace mmpr {
 class FileWriter {
 public:
     FileWriter(const std::string& filepath);
+    virtual ~FileWriter();
 
     virtual void write(const uint8_t* data, size_t size) = 0;
 

--- a/include/mmpr/filesystem/writing/FileWriter.hpp
+++ b/include/mmpr/filesystem/writing/FileWriter.hpp
@@ -9,7 +9,7 @@ namespace mmpr {
 
 class FileWriter {
 public:
-    FileWriter(const std::string& filepath) : mFilepath(filepath) {}
+    FileWriter(const std::string& filepath);
 
     virtual void write(const uint8_t* data, size_t size) = 0;
 

--- a/include/mmpr/filesystem/writing/StreamFileWriter.hpp
+++ b/include/mmpr/filesystem/writing/StreamFileWriter.hpp
@@ -8,12 +8,9 @@ namespace mmpr {
 
 class StreamFileWriter : public FileWriter {
 public:
-    StreamFileWriter(const std::string& filepath)
-        : FileWriter(filepath), mOutputFileStream(mFilepath) {}
+    StreamFileWriter(const std::string& filepath);
 
-    void write(const uint8_t* data, size_t size) override {
-        mOutputFileStream.write((const char*)data, size);
-    }
+    void write(const uint8_t* data, size_t size) override;
 
 private:
     std::ofstream mOutputFileStream;

--- a/include/mmpr/mmpr.hpp
+++ b/include/mmpr/mmpr.hpp
@@ -36,7 +36,7 @@ struct Packet {
 };
 
 struct TraceInterface {
-    TraceInterface(){};
+    TraceInterface() = default;
     TraceInterface(std::optional<std::string> name,
                    std::optional<std::string> description,
                    std::optional<std::string> filter,

--- a/include/mmpr/mmpr.hpp
+++ b/include/mmpr/mmpr.hpp
@@ -31,7 +31,7 @@ struct Packet {
     uint32_t timestampMicroseconds{0};
     uint32_t captureLength{0};
     uint32_t length{0};
-    int interfaceIndex{-1};
+    int32_t interfaceIndex{-1};
     const uint8_t* data{nullptr};
 };
 
@@ -214,7 +214,7 @@ struct Option {
      *
      * @return total length of option including padding
      */
-    uint32_t totalLength() const { return 4 + length + ((4 - length % 4) % 4); }
+    uint32_t totalLength() const { return 4u + length + ((4u - length % 4u) % 4u); }
 };
 
 struct SectionHeaderBlock {

--- a/include/mmpr/modified_pcap/ModifiedPcapParser.hpp
+++ b/include/mmpr/modified_pcap/ModifiedPcapParser.hpp
@@ -6,8 +6,8 @@
 #if __linux__
 #include <netinet/in.h>
 #elif _WIN32
-#include <winsock2.h>
 #include <windows.h>
+#include <winsock2.h>
 #endif
 #include <sstream>
 #include <stdexcept>
@@ -36,43 +36,7 @@ public:
      *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      */
-    static void readFileHeader(const uint8_t* data, modified_pcap::FileHeader& mpfh) {
-        auto magicNumber = *(uint32_t*)&data[0];
-        if (magicNumber != MODIFIED_PCAP &&
-            magicNumber != MODIFIED_PCAP_BE) {
-            std::stringstream sstream;
-            sstream << std::hex << magicNumber;
-            std::string hex = sstream.str();
-            std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
-            throw std::runtime_error(
-                "Expected raw file header to start with magic numbers 0xA1B2CD34 or "
-                "0x34CDB2A1, but instead got: 0x" +
-                hex);
-        }
-
-        mpfh.majorVersion = *(uint16_t*)&data[4];
-        mpfh.minorVersion = *(uint16_t*)&data[6];
-        mpfh.thiszone = *(int32_t*)&data[8];
-        mpfh.sigfigs = *(uint32_t*)&data[12];
-        mpfh.snapLength = *(uint32_t*)&data[16];
-        mpfh.linkType = *(uint32_t*)&data[20];
-
-        if (magicNumber == MODIFIED_PCAP_BE) {
-            mpfh.majorVersion = ntohs(mpfh.majorVersion);
-            mpfh.minorVersion = ntohs(mpfh.minorVersion);
-            mpfh.thiszone = ntohl(mpfh.thiszone);
-            mpfh.sigfigs = ntohl(mpfh.sigfigs);
-            mpfh.snapLength = ntohl(mpfh.snapLength);
-            mpfh.linkType = ntohl(mpfh.linkType);
-        }
-
-        MMPR_DEBUG_LOG_1("--- [Modified PCAP File Header %p] ---\n", (void*)data);
-        MMPR_DEBUG_LOG_2("[MPFH] Version: %u.%u\n", mpfh.majorVersion, mpfh.minorVersion);
-        MMPR_DEBUG_LOG_1("[MPFH] This Zone: %i\n", mpfh.thiszone);
-        MMPR_DEBUG_LOG_1("[MPFH] Sigfigs: %u\n", mpfh.sigfigs);
-        MMPR_DEBUG_LOG_1("[MPFH] Snap Length: %u\n", mpfh.snapLength);
-        MMPR_DEBUG_LOG_1("[MPFH] Link Type: %u\n", mpfh.linkType);
-    }
+    static void readFileHeader(const uint8_t* data, modified_pcap::FileHeader& mpfh);
 
     /**
      *                         1                   2                   3
@@ -96,44 +60,10 @@ public:
      *    /                                                               /
      *    +---------------------------------------------------------------+
      */
-    static void readPacketRecord(const uint8_t* data, modified_pcap::PacketRecord& mppr) {
-        mppr.timestampSeconds = *(uint32_t*)&data[0];
-        mppr.timestampSubSeconds = *(uint32_t*)&data[4];
-        mppr.captureLength = *(uint32_t*)&data[8];
-        mppr.length = *(uint32_t*)&data[12];
-
-        mppr.interfaceIndex = *(uint32_t*)&data[16];
-        mppr.protocol = *(uint16_t*)&data[20];
-        mppr.packetType = data[22];
-        mppr.padding = data[23];
-
-        if (mppr.captureLength > 0) {
-            mppr.data = &data[24];
-        }
-
-        MMPR_DEBUG_LOG_1("--- [Modified PCAP Packet Record %p] ---\n", (void*)data);
-        MMPR_DEBUG_LOG_1("[MPPR] Timestamp Seconds: %u\n", mppr.timestampSeconds);
-        MMPR_DEBUG_LOG_1("[MPPR] Timestamp SubSeconds: %u\n", mppr.timestampSubSeconds);
-        MMPR_DEBUG_LOG_1("[MPPR] Capture Length: %u\n", mppr.captureLength);
-        MMPR_DEBUG_LOG_1("[MPPR] Length: %u\n", mppr.length);
-        MMPR_DEBUG_LOG_1("[MPPR] Interface Index: %u\n", mppr.interfaceIndex);
-        MMPR_DEBUG_LOG_1("[MPPR] Protocol: %u\n", mppr.protocol);
-        MMPR_DEBUG_LOG_1("[MPPR] Packet Type: %u\n", mppr.packetType);
-        MMPR_DEBUG_LOG_1("[MPPR] Padding: %u\n", mppr.padding);
-        MMPR_DEBUG_LOG_1("[MPPR] Data: %p\n", (void*)mppr.data);
-    }
+    static void readPacketRecord(const uint8_t* data, modified_pcap::PacketRecord& mppr);
 
     static void readPacketRecordBE(const uint8_t* data,
-                                   modified_pcap::PacketRecord& mppr) {
-        readPacketRecord(data, mppr);
-
-        mppr.timestampSeconds = ntohl(mppr.timestampSeconds);
-        mppr.timestampSubSeconds = ntohl(mppr.timestampSubSeconds);
-        mppr.captureLength = ntohl(mppr.captureLength);
-        mppr.length = ntohl(mppr.length);
-        mppr.interfaceIndex = ntohl(mppr.interfaceIndex);
-        mppr.protocol = ntohs(mppr.protocol);
-    }
+                                   modified_pcap::PacketRecord& mppr);
 };
 
 } // namespace mmpr

--- a/include/mmpr/modified_pcap/ModifiedPcapParser.hpp
+++ b/include/mmpr/modified_pcap/ModifiedPcapParser.hpp
@@ -6,8 +6,8 @@
 #if __linux__
 #include <netinet/in.h>
 #elif _WIN32
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #endif
 #include <sstream>
 #include <stdexcept>

--- a/include/mmpr/modified_pcap/ModifiedPcapReader.hpp
+++ b/include/mmpr/modified_pcap/ModifiedPcapReader.hpp
@@ -42,10 +42,6 @@ private:
     uint16_t mDataLinkType{101};
 };
 
-template class ModifiedPcapReader<FReadFileReader>;
-template class ModifiedPcapReader<MMapFileReader>;
-template class ModifiedPcapReader<ZstdFileReader>;
-
 typedef ModifiedPcapReader<FReadFileReader> FReadModifiedPcapReader;
 typedef ModifiedPcapReader<MMapFileReader> MMModifiedPcapReader;
 typedef ModifiedPcapReader<ZstdFileReader> ZstdModifiedPcapReader;

--- a/include/mmpr/modified_pcap/ModifiedPcapReader.hpp
+++ b/include/mmpr/modified_pcap/ModifiedPcapReader.hpp
@@ -18,46 +18,13 @@ class ModifiedPcapReader : public Reader {
                   "TReader must be a subclass of FileReader");
 
 public:
-    ModifiedPcapReader(const std::string& filepath) : mReader(filepath) {
-        modified_pcap::FileHeader fileHeader{};
-        ModifiedPcapParser::readFileHeader(mReader.data(), fileHeader);
-        mReader.mOffset += 24;
-    }
+    ModifiedPcapReader(const std::string& filepath);
 
-    ModifiedPcapReader(TReader&& reader) : mReader(std::forward<TReader>(reader)) {
-        modified_pcap::FileHeader fileHeader{};
-        ModifiedPcapParser::readFileHeader(mReader.data(), fileHeader);
-        mReader.mOffset += 24;
-    }
+    ModifiedPcapReader(TReader&& reader);
 
-    bool isExhausted() const override { return mReader.isExhausted(); }
+    bool isExhausted() const override;
 
-    bool readNextPacket(Packet& packet) override {
-        if (isExhausted()) {
-            // nothing more to read
-            return false;
-        }
-
-        // make sure there are enough bytes to read
-        if (mReader.getSafeToReadSize() < 24) {
-            throw std::runtime_error(
-                "Expected to read at least one more raw packet record (24 bytes "
-                "at least), but there are only " +
-                std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
-        }
-
-        modified_pcap::PacketRecord packetRecord{};
-        ModifiedPcapParser::readPacketRecord(&mReader.data()[mReader.mOffset],
-                                             packetRecord);
-        packet.timestampSeconds = packetRecord.timestampSeconds;
-        packet.captureLength = packetRecord.captureLength;
-        packet.length = packetRecord.length;
-        packet.data = packetRecord.data;
-
-        mReader.mOffset += 24 + packetRecord.captureLength;
-
-        return true;
-    }
+    bool readNextPacket(Packet& packet) override;
 
     size_t getFileSize() const override { return mReader.mFileSize; }
     std::string getFilepath() const override { return mReader.mFilepath; }
@@ -74,6 +41,10 @@ private:
     TReader mReader;
     uint16_t mDataLinkType{101};
 };
+
+template class ModifiedPcapReader<FReadFileReader>;
+template class ModifiedPcapReader<MMapFileReader>;
+template class ModifiedPcapReader<ZstdFileReader>;
 
 typedef ModifiedPcapReader<FReadFileReader> FReadModifiedPcapReader;
 typedef ModifiedPcapReader<MMapFileReader> MMModifiedPcapReader;

--- a/include/mmpr/pcap/PcapParser.hpp
+++ b/include/mmpr/pcap/PcapParser.hpp
@@ -27,42 +27,7 @@ public:
      *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
      */
-    static void readFileHeader(const uint8_t* data, pcap::FileHeader& fh) {
-        auto magicNumber = *(const uint32_t*)&data[0];
-        if (magicNumber != PCAP_MICROSECONDS && magicNumber != PCAP_NANOSECONDS) {
-            std::stringstream sstream;
-            sstream << std::hex << magicNumber;
-            std::string hex = sstream.str();
-            std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
-            throw std::runtime_error(
-                "Expected PCAP file header to start with magic numbers 0xA1B2C3D4 or "
-                "0xA1B23C4D, but instead got: 0x" +
-                hex);
-        }
-
-        if (magicNumber == 0xA1B2C3D4) {
-            fh.timestampFormat = pcap::FileHeader::MICROSECONDS;
-        } else {
-            fh.timestampFormat = pcap::FileHeader::NANOSECONDS;
-        }
-
-        fh.majorVersion = *(const uint16_t*)&data[4];
-        fh.minorVersion = *(const uint16_t*)&data[6];
-
-        fh.snapLength = *(const uint32_t*)&data[16];
-        fh.linkType = *(const uint16_t*)&data[20];
-        fh.fcsSequence = *(const uint16_t*)&data[22];
-
-        MMPR_DEBUG_LOG_1("--- [File Header %p] ---\n", (void*)data);
-        MMPR_DEBUG_LOG_1("[FH] Timestamp Format: %s\n",
-                         fh.timestampFormat == pcap::FileHeader::MICROSECONDS
-                             ? "MICROSECONDS"
-                             : "NANOSECONDS");
-        MMPR_DEBUG_LOG_2("[FH] Version: %u.%u\n", fh.majorVersion, fh.minorVersion);
-        MMPR_DEBUG_LOG_1("[FH] Snap Length: %u\n", fh.snapLength);
-        MMPR_DEBUG_LOG_1("[FH] FCS Sequence: %u\n", fh.fcsSequence);
-        MMPR_DEBUG_LOG_1("[FH] Link Type: %u\n", fh.linkType);
-    }
+    static void readFileHeader(const uint8_t* data, pcap::FileHeader& fh);
 
     /**
      *                         1                   2                   3
@@ -82,22 +47,7 @@ public:
      *    /                                                               /
      *    +---------------------------------------------------------------+
      */
-    static void readPacketRecord(const uint8_t* data, pcap::PacketRecord& pr) {
-        pr.timestampSeconds = *(const uint32_t*)&data[0];
-        pr.timestampSubSeconds = *(const uint32_t*)&data[4];
-        pr.captureLength = *(const uint32_t*)&data[8];
-        pr.length = *(const uint32_t*)&data[12];
-        if (pr.captureLength > 0) {
-            pr.data = &data[16];
-        }
-
-        MMPR_DEBUG_LOG_1("--- [Packet Record %p] ---\n", (void*)data);
-        MMPR_DEBUG_LOG_1("[PR] Timestamp Seconds: %u\n", pr.timestampSeconds);
-        MMPR_DEBUG_LOG_1("[PR] Timestamp SubSeconds: %u\n", pr.timestampSubSeconds);
-        MMPR_DEBUG_LOG_1("[PR] Capture Length: %u\n", pr.captureLength);
-        MMPR_DEBUG_LOG_1("[PR] Length: %u\n", pr.length);
-        MMPR_DEBUG_LOG_1("[PR] Data: %p\n", (void*)pr.data);
-    }
+    static void readPacketRecord(const uint8_t* data, pcap::PacketRecord& pr);
 };
 
 } // namespace mmpr

--- a/include/mmpr/pcap/PcapReader.hpp
+++ b/include/mmpr/pcap/PcapReader.hpp
@@ -45,10 +45,6 @@ private:
     pcap::FileHeader::TimestampFormat mTimestampFormat{pcap::FileHeader::MICROSECONDS};
 };
 
-template class PcapReader<FReadFileReader>;
-template class PcapReader<MMapFileReader>;
-template class PcapReader<ZstdFileReader>;
-
 typedef PcapReader<FReadFileReader> FReadPcapReader;
 typedef PcapReader<MMapFileReader> MMPcapReader;
 typedef PcapReader<ZstdFileReader> ZstdPcapReader;

--- a/include/mmpr/pcap/PcapReader.hpp
+++ b/include/mmpr/pcap/PcapReader.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 namespace mmpr {
 
@@ -19,56 +20,17 @@ class PcapReader : public Reader {
                   "TReader must be a subclass of FileReader");
 
 public:
-    PcapReader(const std::string& filepath) : mReader(filepath) {
-        pcap::FileHeader fileHeader{};
-        PcapParser::readFileHeader(mReader.data(), fileHeader);
-        mDataLinkType = fileHeader.linkType;
-        mTimestampFormat = fileHeader.timestampFormat;
-        mReader.mOffset += 24;
-    }
+    PcapReader(const std::string& filepath);
 
-    PcapReader(TReader&& reader) : mReader(std::forward<TReader>(reader)) {
-        pcap::FileHeader fileHeader{};
-        PcapParser::readFileHeader(mReader.data(), fileHeader);
-        mDataLinkType = fileHeader.linkType;
-        mTimestampFormat = fileHeader.timestampFormat;
-        mReader.mOffset += 24;
-    }
+    PcapReader(TReader&& reader);
 
-    bool isExhausted() const { return mReader.isExhausted(); }
+    bool isExhausted() const override;
 
-    bool readNextPacket(Packet& packet) {
-        if (isExhausted()) {
-            // nothing more to read
-            return false;
-        }
+    bool readNextPacket(Packet& packet) override;
 
-        // make sure there are enough bytes to read
-        if (mReader.getSafeToReadSize() < 16) {
-            throw std::runtime_error(
-                "Expected to read at least one more packet record (16 bytes "
-                "at least), but there are only " +
-                std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
-        }
-
-        pcap::PacketRecord packetRecord{};
-        PcapParser::readPacketRecord(&mReader.data()[mReader.mOffset], packetRecord);
-        packet.timestampSeconds = packetRecord.timestampSeconds;
-        packet.timestampMicroseconds = mTimestampFormat == pcap::FileHeader::MICROSECONDS
-                                           ? packetRecord.timestampSubSeconds
-                                           : packetRecord.timestampSubSeconds / 1000;
-        packet.captureLength = packetRecord.captureLength;
-        packet.length = packetRecord.length;
-        packet.data = packetRecord.data;
-
-        mReader.mOffset += 16 + packetRecord.captureLength;
-
-        return true;
-    }
-
-    size_t getFileSize() const { return mReader.mFileSize; }
+    size_t getFileSize() const override { return mReader.mFileSize; }
     std::string getFilepath() const override { return mReader.mFilepath; }
-    size_t getCurrentOffset() const { return mReader.mOffset; }
+    size_t getCurrentOffset() const override { return mReader.mOffset; }
     uint16_t getDataLinkType() const override { return mDataLinkType; }
     std::vector<TraceInterface> getTraceInterfaces() const override {
         return std::vector<TraceInterface>();
@@ -82,6 +44,10 @@ private:
     uint16_t mDataLinkType{0};
     pcap::FileHeader::TimestampFormat mTimestampFormat{pcap::FileHeader::MICROSECONDS};
 };
+
+template class PcapReader<FReadFileReader>;
+template class PcapReader<MMapFileReader>;
+template class PcapReader<ZstdFileReader>;
 
 typedef PcapReader<FReadFileReader> FReadPcapReader;
 typedef PcapReader<MMapFileReader> MMPcapReader;

--- a/include/mmpr/pcap/PcapWriter.hpp
+++ b/include/mmpr/pcap/PcapWriter.hpp
@@ -13,52 +13,17 @@ class PcapWriter : public Writer {
                   "TWriter must be a subclass of FileWriter");
 
 public:
-    PcapWriter(const std::string& filepath) : mWriter(filepath) { writePcapHeader(); }
+    PcapWriter(const std::string& filepath);
 
-    void write(const Packet& packet) override {
-        struct PcapPacketHeader {
-            uint32_t timestampSeconds;      /* timestamp seconds */
-            uint32_t timestampMicroseconds; /* timestamp microseconds */
-            uint32_t captureLength;         /* number of octets of packet saved in file */
-            uint32_t length;                /* actual length of packet */
-        };
-
-        PcapPacketHeader pcapPacketHeader;
-        pcapPacketHeader.timestampSeconds = packet.timestampSeconds;
-        pcapPacketHeader.timestampMicroseconds = packet.timestampMicroseconds;
-        pcapPacketHeader.captureLength = packet.captureLength;
-        pcapPacketHeader.length = packet.length;
-
-        mWriter.write((uint8_t*)&pcapPacketHeader, sizeof(pcapPacketHeader));
-        mWriter.write(packet.data, packet.captureLength);
-    }
+    void write(const Packet& packet) override;
 
 private:
-    void writePcapHeader() {
-        struct PcapHeader {
-            uint32_t magicNumber;  // magic number
-            uint16_t versionMajor; // major version number
-            uint16_t versionMinor; // minor version number
-            int32_t thisZone;      // GMT to local correction
-            uint32_t sigfigs;      // accuracy of timestamps
-            uint32_t snapLength;   // max length of captured packets, in octets
-            uint32_t dataLinkType; // data link type
-        };
-
-        PcapHeader pcapHeader;
-        pcapHeader.magicNumber = PCAP_MICROSECONDS;
-        pcapHeader.versionMajor = 2;
-        pcapHeader.versionMinor = 4;
-        pcapHeader.thisZone = 0;       // TODO account for timezone offset
-        pcapHeader.sigfigs = 0;        // in practice all tools set this to 0
-        pcapHeader.snapLength = 65535; // TODO support different snap lengths
-        pcapHeader.dataLinkType = 1;   // TODO support more link types than DLT_EN10MB
-
-        mWriter.write((uint8_t*)&pcapHeader, sizeof(pcapHeader));
-    }
+    void writePcapHeader();
 
     TWriter mWriter;
 };
+
+template class PcapWriter<StreamFileWriter>;
 
 typedef PcapWriter<StreamFileWriter> StreamPcapWriter;
 

--- a/include/mmpr/pcap/PcapWriter.hpp
+++ b/include/mmpr/pcap/PcapWriter.hpp
@@ -23,8 +23,6 @@ private:
     TWriter mWriter;
 };
 
-template class PcapWriter<StreamFileWriter>;
-
 typedef PcapWriter<StreamFileWriter> StreamPcapWriter;
 
 } // namespace mmpr

--- a/include/mmpr/pcapng/PcapNgBlockOptionParser.hpp
+++ b/include/mmpr/pcapng/PcapNgBlockOptionParser.hpp
@@ -21,9 +21,7 @@ public:
      * @param option the option containing the string value
      * @return string value
      */
-    static std::string parseUTF8(const pcapng::Option& option) {
-        return std::string(reinterpret_cast<const char*>(option.value), option.length);
-    }
+    static std::string parseUTF8(const pcapng::Option& option);
 };
 
 } // namespace mmpr

--- a/include/mmpr/pcapng/PcapNgReader.hpp
+++ b/include/mmpr/pcapng/PcapNgReader.hpp
@@ -83,10 +83,6 @@ private:
     } mMetadata{};
 };
 
-template class PcapNgReader<FReadFileReader>;
-template class PcapNgReader<MMapFileReader>;
-template class PcapNgReader<ZstdFileReader>;
-
 typedef PcapNgReader<FReadFileReader> FReadPcapNgReader;
 typedef PcapNgReader<MMapFileReader> MMPcapNgReader;
 typedef PcapNgReader<ZstdFileReader> ZstdPcapNgReader;

--- a/include/mmpr/pcapng/PcapNgReader.hpp
+++ b/include/mmpr/pcapng/PcapNgReader.hpp
@@ -20,128 +20,13 @@ class PcapNgReader : public Reader {
                   "TReader must be a subclass of FileReader");
 
 public:
-    PcapNgReader(const std::string& filepath) : mReader(filepath) {
-        uint32_t magicNumber = *(uint32_t*)mReader.data();
-        if (magicNumber != PCAPNG) {
-            std::stringstream sstream;
-            sstream << std::hex << magicNumber;
-            std::string hex = sstream.str();
-            std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
-            throw std::runtime_error(
-                "Expected PcapNG format to start with appropriate magic "
-                "number, instead got: 0x" +
-                hex + ", possibly little/big endian issue while reading file " +
-                filepath);
-        }
-    }
+    PcapNgReader(const std::string& filepath);
 
-    PcapNgReader(TReader&& reader) : mReader(std::forward<TReader>(reader)) {
-        uint32_t magicNumber = *(uint32_t*)mReader.data();
-        if (magicNumber != PCAPNG) {
-            std::stringstream sstream;
-            sstream << std::hex << magicNumber;
-            std::string hex = sstream.str();
-            std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
-            throw std::runtime_error(
-                "Expected PcapNG format to start with appropriate magic "
-                "number, instead got: 0x" +
-                hex + ", possibly little/big endian issue while reading file " +
-                getFilepath());
-        }
-    }
+    PcapNgReader(TReader&& reader);
 
-    bool isExhausted() const override { return mReader.isExhausted(); }
+    bool isExhausted() const override;
 
-    bool readNextPacket(Packet& packet) override {
-        if (isExhausted()) {
-            // nothing more to read
-            return false;
-        }
-
-        // make sure there are enough bytes to read
-        if (mReader.getSafeToReadSize() < 8) {
-            throw std::runtime_error(
-                "Expected to read at least one more block (8 bytes at "
-                "least), but there are only " +
-                std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
-        }
-
-        uint32_t blockType = *(uint32_t*)&mReader.data()[mReader.mOffset];
-        uint32_t blockTotalLength = *(uint32_t*)&mReader.data()[mReader.mOffset + 4];
-
-        // TODO add support for Simple Packet Blocks
-        while (blockType != MMPR_ENHANCED_PACKET_BLOCK &&
-               blockType != MMPR_PACKET_BLOCK) {
-            if (blockType == MMPR_SECTION_HEADER_BLOCK) {
-                pcapng::SectionHeaderBlock shb{};
-                PcapNgBlockParser::readSHB(&mReader.data()[mReader.mOffset], shb);
-                mMetadata.comment = shb.options.comment;
-                mMetadata.os = shb.options.os;
-                mMetadata.hardware = shb.options.hardware;
-                mMetadata.userApplication = shb.options.userApplication;
-            } else if (blockType == MMPR_INTERFACE_DESCRIPTION_BLOCK) {
-                pcapng::InterfaceDescriptionBlock idb{};
-                PcapNgBlockParser::readIDB(&mReader.data()[mReader.mOffset], idb);
-                mDataLinkType = idb.linkType;
-                mMetadata.timestampResolution = idb.options.timestampResolution;
-                mTraceInterfaces.emplace_back(idb.options.name, idb.options.description,
-                                              idb.options.filter, idb.options.os);
-            }
-
-            mReader.mOffset += blockTotalLength;
-
-            if (isExhausted()) {
-                // we have reached the end of the file
-                return false;
-            }
-
-            // make sure there are enough bytes to read
-            if (mReader.getSafeToReadSize() < 8) {
-                throw std::runtime_error(
-                    "Expected to read at least one more block (8 bytes at "
-                    "least), but there are only " +
-                    std::to_string(mReader.getSafeToReadSize()) +
-                    " bytes left in the file");
-            }
-
-            // try to read next block type
-            blockType = *(const uint32_t*)&mReader.data()[mReader.mOffset];
-            blockTotalLength = *(const uint32_t*)&mReader.data()[mReader.mOffset + 4];
-        }
-
-        switch (blockType) {
-        case MMPR_ENHANCED_PACKET_BLOCK: {
-            pcapng::EnhancedPacketBlock epb{};
-            PcapNgBlockParser::readEPB(&mReader.data()[mReader.mOffset], epb);
-            util::calculateTimestamps(mMetadata.timestampResolution, epb.timestampHigh,
-                                      epb.timestampLow, &(packet.timestampSeconds),
-                                      &(packet.timestampMicroseconds));
-            packet.captureLength = epb.capturePacketLength;
-            packet.length = epb.originalPacketLength;
-            packet.data = epb.packetData;
-            packet.interfaceIndex = epb.interfaceId;
-
-            mReader.mOffset += epb.blockTotalLength;
-            break;
-        }
-        case MMPR_PACKET_BLOCK: {
-            pcapng::PacketBlock pb{};
-            PcapNgBlockParser::readPB(&mReader.data()[mReader.mOffset], pb);
-            util::calculateTimestamps(mMetadata.timestampResolution, pb.timestampHigh,
-                                      pb.timestampLow, &(packet.timestampSeconds),
-                                      &(packet.timestampMicroseconds));
-            packet.captureLength = pb.capturePacketLength;
-            packet.length = pb.originalPacketLength;
-            packet.data = pb.packetData;
-            packet.interfaceIndex = pb.interfaceId;
-
-            mReader.mOffset += pb.blockTotalLength;
-            break;
-        }
-        }
-
-        return true;
-    }
+    bool readNextPacket(Packet& packet) override;
 
     /**
      * 3.1.  General Block Structure
@@ -159,78 +44,7 @@ public:
      *   |                      Block Total Length                       |
      *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      */
-    uint32_t readBlock() override {
-        const auto blockType = *(const uint32_t*)&mReader.data()[mReader.mOffset];
-        const auto blockTotalLength =
-            *(const uint32_t*)&mReader.data()[mReader.mOffset + 4];
-
-        switch (blockType) {
-        case MMPR_SECTION_HEADER_BLOCK: {
-            pcapng::SectionHeaderBlock shb{};
-            PcapNgBlockParser::readSHB(&mReader.data()[mReader.mOffset], shb);
-            mMetadata.comment = shb.options.comment;
-            mMetadata.os = shb.options.os;
-            mMetadata.hardware = shb.options.hardware;
-            mMetadata.userApplication = shb.options.userApplication;
-            break;
-        }
-        case MMPR_INTERFACE_DESCRIPTION_BLOCK: {
-            pcapng::InterfaceDescriptionBlock idb{};
-            PcapNgBlockParser::readIDB(&mReader.data()[mReader.mOffset], idb);
-            mDataLinkType = idb.linkType;
-            mMetadata.timestampResolution = idb.options.timestampResolution;
-            mTraceInterfaces.emplace_back(idb.options.name, idb.options.description,
-                                          idb.options.filter, idb.options.os);
-            break;
-        }
-        case MMPR_ENHANCED_PACKET_BLOCK: {
-            pcapng::EnhancedPacketBlock epb{};
-            PcapNgBlockParser::readEPB(&mReader.data()[mReader.mOffset], epb);
-            break;
-        }
-        case MMPR_PACKET_BLOCK: {
-            // deprecated in newer versions of PcapNG
-            pcapng::PacketBlock pb{};
-            PcapNgBlockParser::readPB(&mReader.data()[mReader.mOffset], pb);
-            break;
-        }
-        case MMPR_SIMPLE_PACKET_BLOCK: {
-            MMPR_WARN("Parsing of Simple Packet Blocks not implemented, skipping\n");
-            break;
-        }
-        case MMPR_NAME_RESOLUTION_BLOCK: {
-            MMPR_WARN("Parsing of Name Resolution Blocks not implemented, skipping\n");
-            break;
-        }
-        case MMPR_INTERFACE_STATISTICS_BLOCK: {
-            pcapng::InterfaceStatisticsBlock isb{};
-            PcapNgBlockParser::readISB(&mReader.data()[mReader.mOffset], isb);
-            break;
-        }
-        case MMPR_DECRYPTION_SECRETS_BLOCK: {
-            MMPR_WARN("Parsing of Decryption Secrets Blocks not implemented, skipping\n");
-            break;
-        }
-        case MMPR_CUSTOM_CAN_COPY_BLOCK: {
-            MMPR_WARN("Parsing of Custom (Can Copy) Blocks not implemented, skipping\n");
-            break;
-        }
-        case MMPR_CUSTOM_DO_NOT_COPY_BLOCK: {
-            MMPR_WARN(
-                "Parsing of Custom (Do Not Copy) Blocks not implemented, skipping\n");
-            break;
-        }
-        default: {
-            MMPR_WARN_1("Encountered unknown block type: %u, skipping\n", blockType);
-            break;
-        }
-        }
-
-        // skip to next block
-        mReader.mOffset += (size_t)blockTotalLength;
-
-        return blockType;
-    }
+    uint32_t readBlock() override;
 
     size_t getFileSize() const override { return mReader.mFileSize; }
 
@@ -252,13 +66,7 @@ public:
         return mTraceInterfaces;
     }
 
-    TraceInterface getTraceInterface(size_t id) const override {
-        if (id >= mTraceInterfaces.size()) {
-            throw std::out_of_range("Trace interface index " + std::to_string(id) +
-                                    " is out of range");
-        }
-        return mTraceInterfaces[id];
-    }
+    TraceInterface getTraceInterface(size_t id) const override;
 
 private:
     TReader mReader;
@@ -274,6 +82,10 @@ private:
         uint32_t timestampResolution{1000000 /* 10^6 */};
     } mMetadata{};
 };
+
+template class PcapNgReader<FReadFileReader>;
+template class PcapNgReader<MMapFileReader>;
+template class PcapNgReader<ZstdFileReader>;
 
 typedef PcapNgReader<FReadFileReader> FReadPcapNgReader;
 typedef PcapNgReader<MMapFileReader> MMPcapNgReader;

--- a/include/mmpr/util.hpp
+++ b/include/mmpr/util.hpp
@@ -40,9 +40,10 @@ namespace util {
 }
 
 [[maybe_unused]] static double fromIfTsresolDouble(const uint8_t value) {
-    uint8_t mostSignificantBit = value & 0x80;
-    uint8_t remainingBits = value & 0x7F;
+    uint8_t mostSignificantBit = value & 0x80u;
+    uint8_t remainingBits = value & 0x7Fu;
 
+    // TODO test this code
     if (mostSignificantBit == 0) {
         // most significant bit is 0, rest of bits is negative power of 10
         return std::pow(10, -remainingBits);
@@ -53,15 +54,20 @@ namespace util {
 }
 
 [[maybe_unused]] static uint32_t fromIfTsresolUInt(const uint8_t value) {
-    uint8_t mostSignificantBit = value & 0x80;
-    uint8_t remainingBits = value & 0x7F;
+    uint8_t mostSignificantBit = value & 0x80u;
+    uint8_t remainingBits = value & 0x7Fu;
 
+    // TODO test this code
     if (mostSignificantBit == 0) {
         // most significant bit is 0, rest of bits is negative power of 10
-        return std::pow(10, remainingBits);
+        uint32_t result = 1;
+        for (auto i = 0u; i < remainingBits; ++i) {
+            result *= 10;
+        }
+        return result;
     } else {
-        // most signiticant bit is 1, rest of bits is negative power of 2
-        return std::pow(2, remainingBits);
+        // most significant bit is 1, rest of bits is negative power of 2
+        return 2 << remainingBits;
     }
 }
 
@@ -72,8 +78,8 @@ inline static void calculateTimestamps(uint32_t timestampResolution,
                                        uint32_t* timestampMicroseconds) {
     uint64_t timestamp = (uint64_t)timestampHigh << 32 | timestampLow;
     uint64_t sec = timestamp / timestampResolution;
-    *timestampSeconds = sec;
-    *timestampMicroseconds = timestamp - sec * timestampResolution;
+    *timestampSeconds = static_cast<uint32_t>(sec);
+    *timestampMicroseconds = static_cast<uint32_t>(timestamp - sec * timestampResolution);
 }
 
 } // namespace util

--- a/src/filesystem/reading/FReadFileReader.cpp
+++ b/src/filesystem/reading/FReadFileReader.cpp
@@ -1,1 +1,15 @@
 #include "mmpr/filesystem/reading/FReadFileReader.hpp"
+
+namespace mmpr {
+
+FReadFileReader::FReadFileReader(const std::string& filepath) : FileReader(filepath) {
+    mFileContent = std::unique_ptr<uint8_t>(new uint8_t[mFileSize]);
+    FILE* const inFile = fopen(mFilepath.c_str(), "rb");
+    if (fread(mFileContent.get(), 1, mFileSize, inFile) != mFileSize) {
+        throw std::runtime_error("fread error: " + std::string(strerror(errno)));
+    }
+    fclose(inFile);
+    mFileContentPtr = mFileContent.get();
+}
+
+} // namespace mmpr

--- a/src/filesystem/reading/FReadFileReader.cpp
+++ b/src/filesystem/reading/FReadFileReader.cpp
@@ -1,7 +1,12 @@
 #include "mmpr/filesystem/reading/FReadFileReader.hpp"
 
+#ifdef _WIN32
+#include <stdio.h>
+#endif
+
 namespace mmpr {
 
+#ifdef __linux__
 FReadFileReader::FReadFileReader(const std::string& filepath) : FileReader(filepath) {
     mFileContent = std::unique_ptr<uint8_t>(new uint8_t[mFileSize]);
     FILE* const inFile = fopen(mFilepath.c_str(), "rb");
@@ -11,5 +16,22 @@ FReadFileReader::FReadFileReader(const std::string& filepath) : FileReader(filep
     fclose(inFile);
     mFileContentPtr = mFileContent.get();
 }
+#else
+FReadFileReader::FReadFileReader(const std::string& filepath) : FileReader(filepath) {
+    mFileContent = std::unique_ptr<uint8_t>(new uint8_t[mFileSize]);
+
+    FILE* inFile;
+    errno_t err = fopen_s(&inFile, mFilepath.c_str(), "rb");
+    if (err != 0) {
+        throw std::runtime_error("fopen_s error: " + std::to_string(err));
+    }
+
+    if (fread(mFileContent.get(), 1, mFileSize, inFile) != mFileSize) {
+        throw std::runtime_error("fread error: " + std::to_string(errno));
+    }
+    fclose(inFile);
+    mFileContentPtr = mFileContent.get();
+}
+#endif
 
 } // namespace mmpr

--- a/src/filesystem/reading/FileReader.cpp
+++ b/src/filesystem/reading/FileReader.cpp
@@ -1,1 +1,31 @@
 #include "mmpr/filesystem/reading/FileReader.hpp"
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+using namespace std;
+using namespace std::filesystem;
+
+namespace mmpr {
+
+FileReader::FileReader(const string& filepath)
+    : mFilepath(filepath), mFileSize(file_size(filepath)) {
+    if (filepath.empty()) {
+        throw runtime_error("Cannot read empty filepath");
+    }
+
+    if (!exists(filepath)) {
+        throw runtime_error("Cannot find file " + absolute(filepath).string());
+    }
+}
+
+size_t FileReader::getSafeToReadSize() const {
+    if (mOffset >= mFileSize) {
+        return 0;
+    } else {
+        return mFileSize - mOffset;
+    }
+}
+
+} // namespace mmpr

--- a/src/filesystem/reading/MMapFileReader.cpp
+++ b/src/filesystem/reading/MMapFileReader.cpp
@@ -1,1 +1,53 @@
 #include "mmpr/filesystem/reading/MMapFileReader.hpp"
+
+namespace mmpr {
+
+MMapFileReader::MMapFileReader(const std::string& filepath) : FileReader(filepath) {
+
+#if __linux__
+    mFileDescriptor = ::open(mFilepath.c_str(), O_RDONLY, 0);
+    if (mFileDescriptor < 0) {
+        throw std::runtime_error("Error while reading file " +
+                                 std::filesystem::absolute(mFilepath).string() + ": " +
+                                 strerror(errno));
+    }
+
+    auto mmapResult = mmap(nullptr, mFileSize, PROT_READ, MAP_SHARED, mFileDescriptor, 0);
+    if (mmapResult == MAP_FAILED) {
+        ::close(mFileDescriptor);
+        throw std::runtime_error("Error while mapping file " +
+                                 std::filesystem::absolute(mFilepath).string() + ": " +
+                                 strerror(errno));
+    }
+
+    mOffset = 0;
+    mMappedMemory = reinterpret_cast<const uint8_t*>(mmapResult);
+#elif _WIN32
+    mFileHandle =
+        HandlePtr(CreateFile(mFilepath.c_str(), GENERIC_READ,
+                             /*shared mode*/ 0,
+                             /*security*/ nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                             /*template*/ nullptr));
+    if (!mFileHandle) {
+        throw std::runtime_error("could not create file handle for " + mFilepath);
+    }
+
+    mFileMappingHandle = HandlePtr(CreateFileMapping(mFileHandle.get(), NULL,
+                                                     PAGE_READONLY, /*size high*/ 0,
+                                                     /*size low*/ 0, NULL));
+    if (!mFileMappingHandle) {
+        throw std::runtime_error("could not create file mapping handle for " + mFilepath);
+    }
+
+    // map the input file
+    auto mmapResult = MapViewOfFile(mFileMappingHandle.get(), FILE_MAP_READ, 0, 0, 0);
+    if (mmapResult == nullptr) {
+        throw std::runtime_error("failed to map file to memory: " + mFilepath);
+    }
+
+    mOffset = 0;
+    mMappedMemory = reinterpret_cast<const uint8_t*>(mmapResult);
+#endif
+}
+
+} // namespace mmpr

--- a/src/filesystem/reading/ZstdFileReader.cpp
+++ b/src/filesystem/reading/ZstdFileReader.cpp
@@ -3,7 +3,6 @@
 #include "mmpr/filesystem/reading/FReadFileReader.hpp"
 #include "zstd.h"
 #include <algorithm>
-#include <fstream>
 #include <sstream>
 
 namespace mmpr {
@@ -24,7 +23,6 @@ ZstdFileReader::ZstdFileReader(const std::string& filepath) : FileReader(filepat
         std::stringstream sstream;
         sstream << std::hex << magicNumber;
         std::string hex = sstream.str();
-        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error("Expected ZSTD format to start with appropriate magic "
                                  "number, instead got: 0x" +
                                  hex + ", possibly little/big endian issue");

--- a/src/filesystem/reading/ZstdFileReader.cpp
+++ b/src/filesystem/reading/ZstdFileReader.cpp
@@ -1,7 +1,7 @@
 #include "mmpr/filesystem/reading/ZstdFileReader.hpp"
 
-#include "zstd.h"
 #include "mmpr/filesystem/reading/FReadFileReader.hpp"
+#include "zstd.h"
 #include <algorithm>
 #include <fstream>
 #include <sstream>
@@ -70,5 +70,10 @@ ZstdFileReader::ZstdFileReader(const std::string& filepath) : FileReader(filepat
     mDecompressedDataPtr = mDecompressedData.get();
     mFileSize = decompressedSize;
 }
+
+ZstdFileReader::ZstdFileReader(ZstdFileReader&& other)
+    : FileReader(other.mFilepath),
+      mDecompressedData(std::move(other.mDecompressedData)),
+      mDecompressedDataPtr(mDecompressedData.get()) {}
 
 } // namespace mmpr

--- a/src/filesystem/writing/FileWriter.cpp
+++ b/src/filesystem/writing/FileWriter.cpp
@@ -1,1 +1,7 @@
 #include "mmpr/filesystem/writing/FileWriter.hpp"
+
+namespace mmpr {
+
+FileWriter::FileWriter(const std::string& filepath) : mFilepath(filepath) {}
+
+} // namespace mmpr

--- a/src/filesystem/writing/FileWriter.cpp
+++ b/src/filesystem/writing/FileWriter.cpp
@@ -4,4 +4,6 @@ namespace mmpr {
 
 FileWriter::FileWriter(const std::string& filepath) : mFilepath(filepath) {}
 
+FileWriter::~FileWriter() {}
+
 } // namespace mmpr

--- a/src/filesystem/writing/StreamFileWriter.cpp
+++ b/src/filesystem/writing/StreamFileWriter.cpp
@@ -6,7 +6,7 @@ StreamFileWriter::StreamFileWriter(const std::string& filepath)
     : FileWriter(filepath), mOutputFileStream(mFilepath) {}
 
 void StreamFileWriter::write(const uint8_t* data, size_t size) {
-    mOutputFileStream.write((const char*)data, size);
+    mOutputFileStream.write((const char*)data, static_cast<std::streamsize>(size));
 }
 
 } // namespace mmpr

--- a/src/filesystem/writing/StreamFileWriter.cpp
+++ b/src/filesystem/writing/StreamFileWriter.cpp
@@ -1,1 +1,12 @@
 #include "mmpr/filesystem/writing/StreamFileWriter.hpp"
+
+namespace mmpr {
+
+StreamFileWriter::StreamFileWriter(const std::string& filepath)
+    : FileWriter(filepath), mOutputFileStream(mFilepath) {}
+
+void StreamFileWriter::write(const uint8_t* data, size_t size) {
+    mOutputFileStream.write((const char*)data, size);
+}
+
+} // namespace mmpr

--- a/src/modified_pcap/ModifiedPcapParser.cpp
+++ b/src/modified_pcap/ModifiedPcapParser.cpp
@@ -9,7 +9,6 @@ void ModifiedPcapParser::readFileHeader(const uint8_t* data,
         std::stringstream sstream;
         sstream << std::hex << magicNumber;
         std::string hex = sstream.str();
-        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error(
             "Expected raw file header to start with magic numbers 0xA1B2CD34 or "
             "0x34CDB2A1, but instead got: 0x" +

--- a/src/modified_pcap/ModifiedPcapParser.cpp
+++ b/src/modified_pcap/ModifiedPcapParser.cpp
@@ -1,5 +1,9 @@
 #include "mmpr/modified_pcap/ModifiedPcapParser.hpp"
 
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
+
 namespace mmpr {
 
 void ModifiedPcapParser::readFileHeader(const uint8_t* data,

--- a/src/modified_pcap/ModifiedPcapParser.cpp
+++ b/src/modified_pcap/ModifiedPcapParser.cpp
@@ -1,1 +1,83 @@
 #include "mmpr/modified_pcap/ModifiedPcapParser.hpp"
+
+namespace mmpr {
+
+void ModifiedPcapParser::readFileHeader(const uint8_t* data,
+                                        modified_pcap::FileHeader& mpfh) {
+    auto magicNumber = *(uint32_t*)&data[0];
+    if (magicNumber != MODIFIED_PCAP && magicNumber != MODIFIED_PCAP_BE) {
+        std::stringstream sstream;
+        sstream << std::hex << magicNumber;
+        std::string hex = sstream.str();
+        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
+        throw std::runtime_error(
+            "Expected raw file header to start with magic numbers 0xA1B2CD34 or "
+            "0x34CDB2A1, but instead got: 0x" +
+            hex);
+    }
+
+    mpfh.majorVersion = *(uint16_t*)&data[4];
+    mpfh.minorVersion = *(uint16_t*)&data[6];
+    mpfh.thiszone = *(int32_t*)&data[8];
+    mpfh.sigfigs = *(uint32_t*)&data[12];
+    mpfh.snapLength = *(uint32_t*)&data[16];
+    mpfh.linkType = *(uint32_t*)&data[20];
+
+    if (magicNumber == MODIFIED_PCAP_BE) {
+        mpfh.majorVersion = ntohs(mpfh.majorVersion);
+        mpfh.minorVersion = ntohs(mpfh.minorVersion);
+        mpfh.thiszone = ntohl(mpfh.thiszone);
+        mpfh.sigfigs = ntohl(mpfh.sigfigs);
+        mpfh.snapLength = ntohl(mpfh.snapLength);
+        mpfh.linkType = ntohl(mpfh.linkType);
+    }
+
+    MMPR_DEBUG_LOG_1("--- [Modified PCAP File Header %p] ---\n", (void*)data);
+    MMPR_DEBUG_LOG_2("[MPFH] Version: %u.%u\n", mpfh.majorVersion, mpfh.minorVersion);
+    MMPR_DEBUG_LOG_1("[MPFH] This Zone: %i\n", mpfh.thiszone);
+    MMPR_DEBUG_LOG_1("[MPFH] Sigfigs: %u\n", mpfh.sigfigs);
+    MMPR_DEBUG_LOG_1("[MPFH] Snap Length: %u\n", mpfh.snapLength);
+    MMPR_DEBUG_LOG_1("[MPFH] Link Type: %u\n", mpfh.linkType);
+}
+
+void ModifiedPcapParser::readPacketRecord(const uint8_t* data,
+                                          modified_pcap::PacketRecord& mppr) {
+    mppr.timestampSeconds = *(uint32_t*)&data[0];
+    mppr.timestampSubSeconds = *(uint32_t*)&data[4];
+    mppr.captureLength = *(uint32_t*)&data[8];
+    mppr.length = *(uint32_t*)&data[12];
+
+    mppr.interfaceIndex = *(uint32_t*)&data[16];
+    mppr.protocol = *(uint16_t*)&data[20];
+    mppr.packetType = data[22];
+    mppr.padding = data[23];
+
+    if (mppr.captureLength > 0) {
+        mppr.data = &data[24];
+    }
+
+    MMPR_DEBUG_LOG_1("--- [Modified PCAP Packet Record %p] ---\n", (void*)data);
+    MMPR_DEBUG_LOG_1("[MPPR] Timestamp Seconds: %u\n", mppr.timestampSeconds);
+    MMPR_DEBUG_LOG_1("[MPPR] Timestamp SubSeconds: %u\n", mppr.timestampSubSeconds);
+    MMPR_DEBUG_LOG_1("[MPPR] Capture Length: %u\n", mppr.captureLength);
+    MMPR_DEBUG_LOG_1("[MPPR] Length: %u\n", mppr.length);
+    MMPR_DEBUG_LOG_1("[MPPR] Interface Index: %u\n", mppr.interfaceIndex);
+    MMPR_DEBUG_LOG_1("[MPPR] Protocol: %u\n", mppr.protocol);
+    MMPR_DEBUG_LOG_1("[MPPR] Packet Type: %u\n", mppr.packetType);
+    MMPR_DEBUG_LOG_1("[MPPR] Padding: %u\n", mppr.padding);
+    MMPR_DEBUG_LOG_1("[MPPR] Data: %p\n", (void*)mppr.data);
+}
+
+void ModifiedPcapParser::readPacketRecordBE(const uint8_t* data,
+                                            modified_pcap::PacketRecord& mppr) {
+    readPacketRecord(data, mppr);
+
+    mppr.timestampSeconds = ntohl(mppr.timestampSeconds);
+    mppr.timestampSubSeconds = ntohl(mppr.timestampSubSeconds);
+    mppr.captureLength = ntohl(mppr.captureLength);
+    mppr.length = ntohl(mppr.length);
+    mppr.interfaceIndex = ntohl(mppr.interfaceIndex);
+    mppr.protocol = ntohs(mppr.protocol);
+}
+
+} // namespace mmpr

--- a/src/modified_pcap/ModifiedPcapReader.cpp
+++ b/src/modified_pcap/ModifiedPcapReader.cpp
@@ -50,4 +50,8 @@ bool ModifiedPcapReader<TReader>::readNextPacket(Packet& packet) {
     return true;
 }
 
+template class ModifiedPcapReader<FReadFileReader>;
+template class ModifiedPcapReader<MMapFileReader>;
+template class ModifiedPcapReader<ZstdFileReader>;
+
 } // namespace mmpr

--- a/src/modified_pcap/ModifiedPcapReader.cpp
+++ b/src/modified_pcap/ModifiedPcapReader.cpp
@@ -1,1 +1,53 @@
 #include "mmpr/modified_pcap/ModifiedPcapReader.hpp"
+
+namespace mmpr {
+
+template <typename TReader>
+ModifiedPcapReader<TReader>::ModifiedPcapReader(const std::string& filepath)
+    : mReader(filepath) {
+    modified_pcap::FileHeader fileHeader{};
+    ModifiedPcapParser::readFileHeader(mReader.data(), fileHeader);
+    mReader.mOffset += 24;
+}
+
+template <typename TReader>
+ModifiedPcapReader<TReader>::ModifiedPcapReader(TReader&& reader)
+    : mReader(std::forward<TReader>(reader)) {
+    modified_pcap::FileHeader fileHeader{};
+    ModifiedPcapParser::readFileHeader(mReader.data(), fileHeader);
+    mReader.mOffset += 24;
+}
+
+template <typename TReader>
+bool ModifiedPcapReader<TReader>::isExhausted() const {
+    return mReader.isExhausted();
+}
+
+template <typename TReader>
+bool ModifiedPcapReader<TReader>::readNextPacket(Packet& packet) {
+    if (isExhausted()) {
+        // nothing more to read
+        return false;
+    }
+
+    // make sure there are enough bytes to read
+    if (mReader.getSafeToReadSize() < 24) {
+        throw std::runtime_error(
+            "Expected to read at least one more raw packet record (24 bytes "
+            "at least), but there are only " +
+            std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
+    }
+
+    modified_pcap::PacketRecord packetRecord{};
+    ModifiedPcapParser::readPacketRecord(&mReader.data()[mReader.mOffset], packetRecord);
+    packet.timestampSeconds = packetRecord.timestampSeconds;
+    packet.captureLength = packetRecord.captureLength;
+    packet.length = packetRecord.length;
+    packet.data = packetRecord.data;
+
+    mReader.mOffset += 24 + packetRecord.captureLength;
+
+    return true;
+}
+
+} // namespace mmpr

--- a/src/pcap/PcapParser.cpp
+++ b/src/pcap/PcapParser.cpp
@@ -8,7 +8,6 @@ void PcapParser::readFileHeader(const uint8_t* data, pcap::FileHeader& fh) {
         std::stringstream sstream;
         sstream << std::hex << magicNumber;
         std::string hex = sstream.str();
-        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error(
             "Expected PCAP file header to start with magic numbers 0xA1B2C3D4 or "
             "0xA1B23C4D, but instead got: 0x" +

--- a/src/pcap/PcapParser.cpp
+++ b/src/pcap/PcapParser.cpp
@@ -1,1 +1,59 @@
 #include "mmpr/pcap/PcapParser.hpp"
+
+namespace mmpr {
+
+void PcapParser::readFileHeader(const uint8_t* data, pcap::FileHeader& fh) {
+    auto magicNumber = *(const uint32_t*)&data[0];
+    if (magicNumber != PCAP_MICROSECONDS && magicNumber != PCAP_NANOSECONDS) {
+        std::stringstream sstream;
+        sstream << std::hex << magicNumber;
+        std::string hex = sstream.str();
+        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
+        throw std::runtime_error(
+            "Expected PCAP file header to start with magic numbers 0xA1B2C3D4 or "
+            "0xA1B23C4D, but instead got: 0x" +
+            hex);
+    }
+
+    if (magicNumber == 0xA1B2C3D4) {
+        fh.timestampFormat = pcap::FileHeader::MICROSECONDS;
+    } else {
+        fh.timestampFormat = pcap::FileHeader::NANOSECONDS;
+    }
+
+    fh.majorVersion = *(const uint16_t*)&data[4];
+    fh.minorVersion = *(const uint16_t*)&data[6];
+
+    fh.snapLength = *(const uint32_t*)&data[16];
+    fh.linkType = *(const uint16_t*)&data[20];
+    fh.fcsSequence = *(const uint16_t*)&data[22];
+
+    MMPR_DEBUG_LOG_1("--- [File Header %p] ---\n", (void*)data);
+    MMPR_DEBUG_LOG_1("[FH] Timestamp Format: %s\n",
+                     fh.timestampFormat == pcap::FileHeader::MICROSECONDS
+                         ? "MICROSECONDS"
+                         : "NANOSECONDS");
+    MMPR_DEBUG_LOG_2("[FH] Version: %u.%u\n", fh.majorVersion, fh.minorVersion);
+    MMPR_DEBUG_LOG_1("[FH] Snap Length: %u\n", fh.snapLength);
+    MMPR_DEBUG_LOG_1("[FH] FCS Sequence: %u\n", fh.fcsSequence);
+    MMPR_DEBUG_LOG_1("[FH] Link Type: %u\n", fh.linkType);
+}
+
+void PcapParser::readPacketRecord(const uint8_t* data, pcap::PacketRecord& pr) {
+    pr.timestampSeconds = *(const uint32_t*)&data[0];
+    pr.timestampSubSeconds = *(const uint32_t*)&data[4];
+    pr.captureLength = *(const uint32_t*)&data[8];
+    pr.length = *(const uint32_t*)&data[12];
+    if (pr.captureLength > 0) {
+        pr.data = &data[16];
+    }
+
+    MMPR_DEBUG_LOG_1("--- [Packet Record %p] ---\n", (void*)data);
+    MMPR_DEBUG_LOG_1("[PR] Timestamp Seconds: %u\n", pr.timestampSeconds);
+    MMPR_DEBUG_LOG_1("[PR] Timestamp SubSeconds: %u\n", pr.timestampSubSeconds);
+    MMPR_DEBUG_LOG_1("[PR] Capture Length: %u\n", pr.captureLength);
+    MMPR_DEBUG_LOG_1("[PR] Length: %u\n", pr.length);
+    MMPR_DEBUG_LOG_1("[PR] Data: %p\n", (void*)pr.data);
+}
+
+} // namespace mmpr

--- a/src/pcap/PcapReader.cpp
+++ b/src/pcap/PcapReader.cpp
@@ -1,1 +1,59 @@
 #include "mmpr/pcap/PcapReader.hpp"
+
+namespace mmpr {
+
+template <typename TReader>
+PcapReader<TReader>::PcapReader(const std::string& filepath) : mReader(filepath) {
+    pcap::FileHeader fileHeader{};
+    PcapParser::readFileHeader(mReader.data(), fileHeader);
+    mDataLinkType = fileHeader.linkType;
+    mTimestampFormat = fileHeader.timestampFormat;
+    mReader.mOffset += 24;
+}
+
+template <typename TReader>
+PcapReader<TReader>::PcapReader(TReader&& reader)
+    : mReader(std::forward<TReader>(reader)) {
+    pcap::FileHeader fileHeader{};
+    PcapParser::readFileHeader(mReader.data(), fileHeader);
+    mDataLinkType = fileHeader.linkType;
+    mTimestampFormat = fileHeader.timestampFormat;
+    mReader.mOffset += 24;
+}
+
+template <typename TReader>
+bool PcapReader<TReader>::isExhausted() const {
+    return mReader.isExhausted();
+}
+
+template <typename TReader>
+bool PcapReader<TReader>::readNextPacket(Packet& packet) {
+    if (isExhausted()) {
+        // nothing more to read
+        return false;
+    }
+
+    // make sure there are enough bytes to read
+    if (mReader.getSafeToReadSize() < 16) {
+        throw std::runtime_error(
+            "Expected to read at least one more packet record (16 bytes "
+            "at least), but there are only " +
+            std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
+    }
+
+    pcap::PacketRecord packetRecord{};
+    PcapParser::readPacketRecord(&mReader.data()[mReader.mOffset], packetRecord);
+    packet.timestampSeconds = packetRecord.timestampSeconds;
+    packet.timestampMicroseconds = mTimestampFormat == pcap::FileHeader::MICROSECONDS
+                                       ? packetRecord.timestampSubSeconds
+                                       : packetRecord.timestampSubSeconds / 1000;
+    packet.captureLength = packetRecord.captureLength;
+    packet.length = packetRecord.length;
+    packet.data = packetRecord.data;
+
+    mReader.mOffset += 16 + packetRecord.captureLength;
+
+    return true;
+}
+
+} // namespace mmpr

--- a/src/pcap/PcapReader.cpp
+++ b/src/pcap/PcapReader.cpp
@@ -56,4 +56,8 @@ bool PcapReader<TReader>::readNextPacket(Packet& packet) {
     return true;
 }
 
+template class PcapReader<FReadFileReader>;
+template class PcapReader<MMapFileReader>;
+template class PcapReader<ZstdFileReader>;
+
 } // namespace mmpr

--- a/src/pcap/PcapWriter.cpp
+++ b/src/pcap/PcapWriter.cpp
@@ -1,1 +1,53 @@
 #include "mmpr/pcap/PcapWriter.hpp"
+
+namespace mmpr {
+
+template <typename TWriter>
+PcapWriter<TWriter>::PcapWriter(const std::string& filepath) : mWriter(filepath) {
+    writePcapHeader();
+}
+
+template <typename TWriter>
+void PcapWriter<TWriter>::write(const Packet& packet) {
+    struct PcapPacketHeader {
+        uint32_t timestampSeconds;      /* timestamp seconds */
+        uint32_t timestampMicroseconds; /* timestamp microseconds */
+        uint32_t captureLength;         /* number of octets of packet saved in file */
+        uint32_t length;                /* actual length of packet */
+    };
+
+    PcapPacketHeader pcapPacketHeader;
+    pcapPacketHeader.timestampSeconds = packet.timestampSeconds;
+    pcapPacketHeader.timestampMicroseconds = packet.timestampMicroseconds;
+    pcapPacketHeader.captureLength = packet.captureLength;
+    pcapPacketHeader.length = packet.length;
+
+    mWriter.write((uint8_t*)&pcapPacketHeader, sizeof(pcapPacketHeader));
+    mWriter.write(packet.data, packet.captureLength);
+}
+
+template <typename TWriter>
+void PcapWriter<TWriter>::writePcapHeader() {
+    struct PcapHeader {
+        uint32_t magicNumber;  // magic number
+        uint16_t versionMajor; // major version number
+        uint16_t versionMinor; // minor version number
+        int32_t thisZone;      // GMT to local correction
+        uint32_t sigfigs;      // accuracy of timestamps
+        uint32_t snapLength;   // max length of captured packets, in octets
+        uint32_t dataLinkType; // data link type
+    };
+
+    PcapHeader pcapHeader;
+    pcapHeader.magicNumber = PCAP_MICROSECONDS;
+    pcapHeader.versionMajor = 2;
+    pcapHeader.versionMinor = 4;
+    pcapHeader.thisZone = 0;       // TODO account for timezone offset
+    pcapHeader.sigfigs = 0;        // in practice all tools set this to 0
+    pcapHeader.snapLength = 65535; // TODO support different snap lengths
+    pcapHeader.dataLinkType = 1;   // TODO support more link types than DLT_EN10MB
+
+    mWriter.write((uint8_t*)&pcapHeader, sizeof(pcapHeader));
+}
+
+} // namespace mmpr

--- a/src/pcap/PcapWriter.cpp
+++ b/src/pcap/PcapWriter.cpp
@@ -50,4 +50,6 @@ void PcapWriter<TWriter>::writePcapHeader() {
     mWriter.write((uint8_t*)&pcapHeader, sizeof(pcapHeader));
 }
 
+template class PcapWriter<StreamFileWriter>;
+
 } // namespace mmpr

--- a/src/pcapng/PcapNgBlockOptionParser.cpp
+++ b/src/pcapng/PcapNgBlockOptionParser.cpp
@@ -111,7 +111,7 @@ void PcapNgBlockOptionParser::readIDBBlockOption(const uint8_t* data,
         // if_speed: interface speed, in bits per second
         const uint64_t speed = *(const uint64_t*)option.value;
         MMPR_UNUSED(speed);
-        MMPR_DEBUG_LOG_1("[IDB][OPT] Interface Speed: %lu bits/s\n", speed);
+        MMPR_DEBUG_LOG_1("[IDB][OPT] Interface Speed: %lu bits/s\n", static_cast<unsigned long>(speed));
         return;
     }
     case MMPR_BLOCK_OPTION_IDB_TSRESOL: {
@@ -169,7 +169,7 @@ void PcapNgBlockOptionParser::readIDBBlockOption(const uint8_t* data,
         // each packet to obtain the absolute timestamp of a packet
         const int64_t tsoffset = *(const int64_t*)option.value;
         MMPR_UNUSED(tsoffset);
-        MMPR_DEBUG_LOG_1("[IDB][OPT] Timestamp Offset: %li\n", tsoffset);
+        MMPR_DEBUG_LOG_1("[IDB][OPT] Timestamp Offset: %li\n", static_cast<long>(tsoffset));
         return;
     }
     case 15: {
@@ -182,14 +182,14 @@ void PcapNgBlockOptionParser::readIDBBlockOption(const uint8_t* data,
         // if_txspeed: interface transmit speed in bits per second
         const uint64_t txspeed = *(const uint64_t*)option.value;
         MMPR_UNUSED(txspeed);
-        MMPR_DEBUG_LOG_1("[IDB][OPT] Transmit Speed: %lu bits/s\n", txspeed);
+        MMPR_DEBUG_LOG_1("[IDB][OPT] Transmit Speed: %lu bits/s\n", static_cast<unsigned long>(txspeed));
         return;
     }
     case 17: {
         // if_rxspeed: interface receive speed, in bits per second
         const uint64_t rxspeed = *(const uint64_t*)option.value;
         MMPR_UNUSED(rxspeed);
-        MMPR_DEBUG_LOG_1("[IDB][OPT] Receive Speed: %lu bits/s\n", rxspeed);
+        MMPR_DEBUG_LOG_1("[IDB][OPT] Receive Speed: %lu bits/s\n", static_cast<unsigned long>(rxspeed));
         return;
     }
     default: {
@@ -228,14 +228,14 @@ void PcapNgBlockOptionParser::readEPBOption(const uint8_t* data,
         //                and the start of the capture process
         uint64_t dropCount = *(const uint64_t*)option.value;
         MMPR_UNUSED(dropCount);
-        MMPR_DEBUG_LOG_1("[EPB][OPT] Drop Count: %lu packets\n", dropCount);
+        MMPR_DEBUG_LOG_1("[EPB][OPT] Drop Count: %lu packets\n", static_cast<unsigned long>(dropCount));
         return;
     }
     case 5: {
         // epb_packetid: 64-bit unsigned integer that uniquely identifies the packet
         uint64_t packetId = *(const uint64_t*)option.value;
         MMPR_UNUSED(packetId);
-        MMPR_DEBUG_LOG_1("[EPB][OPT] Packet ID: %lu\n", packetId);
+        MMPR_DEBUG_LOG_1("[EPB][OPT] Packet ID: %lu\n", static_cast<unsigned long>(packetId));
         return;
     }
     case 6: {
@@ -285,7 +285,7 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
         //             starting from the beginning of the capture
         uint64_t ifrecv = *(const uint64_t*)option.value;
         MMPR_UNUSED(ifrecv);
-        MMPR_DEBUG_LOG_1("[ISB][OPT] Received Packets: %lu", ifrecv);
+        MMPR_DEBUG_LOG_1("[ISB][OPT] Received Packets: %lu", static_cast<unsigned long>(ifrecv));
         return;
     }
     case 5: {
@@ -293,7 +293,7 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
         //             resources starting from the beginning of the capture
         uint64_t ifdrop = *(const uint64_t*)option.value;
         MMPR_UNUSED(ifdrop);
-        MMPR_DEBUG_LOG_1("[ISB][OPT] Dropped Packets (Interface): %lu", ifdrop);
+        MMPR_DEBUG_LOG_1("[ISB][OPT] Dropped Packets (Interface): %lu", static_cast<unsigned long>(ifdrop));
         return;
     }
     case 6: {
@@ -301,7 +301,7 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
         //                   the beginning of the capture
         uint64_t filteraccept = *(const uint64_t*)option.value;
         MMPR_UNUSED(filteraccept);
-        MMPR_DEBUG_LOG_1("[ISB][OPT] Filtered Packets: %lu", filteraccept);
+        MMPR_DEBUG_LOG_1("[ISB][OPT] Filtered Packets: %lu", static_cast<unsigned long>(filteraccept));
         return;
     }
     case 7: {
@@ -309,7 +309,7 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
         //             from the beginning of the capture
         uint64_t osdrop = *(const uint64_t*)option.value;
         MMPR_UNUSED(osdrop);
-        MMPR_DEBUG_LOG_1("[ISB][OPT] Dropped Packets (OS): %lu", osdrop);
+        MMPR_DEBUG_LOG_1("[ISB][OPT] Dropped Packets (OS): %lu", static_cast<unsigned long>(osdrop));
         return;
     }
     case 8: {
@@ -317,7 +317,7 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
         //               beginning of the capture
         uint64_t usrdeliv = *(const uint64_t*)option.value;
         MMPR_UNUSED(usrdeliv);
-        MMPR_DEBUG_LOG_1("[ISB][OPT] Packets Delivered to User: %lu", usrdeliv);
+        MMPR_DEBUG_LOG_1("[ISB][OPT] Packets Delivered to User: %lu", static_cast<unsigned long>(usrdeliv));
         return;
     }
     default: {

--- a/src/pcapng/PcapNgBlockOptionParser.cpp
+++ b/src/pcapng/PcapNgBlockOptionParser.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 namespace mmpr {
+
 /**
  *                      1                   2                   3
  *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -327,4 +328,9 @@ void PcapNgBlockOptionParser::readISBOption(const uint8_t* data,
     MMPR_DEBUG_LOG_1("[ISB][OPT] Option Code/Type: %u\n", option.type);
     MMPR_DEBUG_LOG_1("[ISB][OPT] Option Length: %u\n", option.length);
 }
+
+std::string PcapNgBlockOptionParser::parseUTF8(const pcapng::Option& option) {
+    return std::string(reinterpret_cast<const char*>(option.value), option.length);
+}
+
 } // namespace mmpr

--- a/src/pcapng/PcapNgBlockParser.cpp
+++ b/src/pcapng/PcapNgBlockParser.cpp
@@ -54,7 +54,7 @@ void PcapNgBlockParser::readSHB(const uint8_t* data, pcapng::SectionHeaderBlock&
     MMPR_DEBUG_LOG_1("[SHB] Block Total Length: %u\n", shb.blockTotalLength);
     MMPR_DEBUG_LOG_1("[SHB] Byte-Order Magic: 0x%08X\n", byteOrderMagic);
     MMPR_DEBUG_LOG_2("[SHB] Version: %u.%u\n", shb.majorVersion, shb.minorVersion);
-    MMPR_DEBUG_LOG_1("[SHB] Section Length: %li\n", shb.sectionLength);
+    MMPR_DEBUG_LOG_1("[SHB] Section Length: %li\n", static_cast<long>(shb.sectionLength));
 
     // standard Section Header Block has size 28 (without any options)
     if (shb.blockTotalLength > 28) {

--- a/src/pcapng/PcapNgBlockParser.cpp
+++ b/src/pcapng/PcapNgBlockParser.cpp
@@ -5,6 +5,7 @@
 #include "mmpr/util.hpp"
 
 namespace mmpr {
+
 /**
  * 4.1.  Section Header Block
  *
@@ -363,4 +364,5 @@ void PcapNgBlockParser::readISB(const uint8_t* data,
     auto blockTotalLength = *(const uint32_t*)&data[isb.blockTotalLength - 4];
     MMPR_ASSERT(isb.blockTotalLength == blockTotalLength);
 }
+
 } // namespace mmpr

--- a/src/pcapng/PcapNgBlockParser.cpp
+++ b/src/pcapng/PcapNgBlockParser.cpp
@@ -145,7 +145,7 @@ void PcapNgBlockParser::readIDB(const uint8_t* data,
             case MMPR_BLOCK_OPTION_IDB_FILTER:
                 // skip first octet (filter code), interpret rest as string
                 idb.options.filter = std::string(
-                    reinterpret_cast<const char*>(&option.value[1]), option.length - 1);
+                    reinterpret_cast<const char*>(&option.value[1]), option.length - 1u);
                 break;
             case MMPR_BLOCK_OPTION_IDB_OS:
                 idb.options.os = PcapNgBlockOptionParser::parseUTF8(option);
@@ -155,7 +155,7 @@ void PcapNgBlockParser::readIDB(const uint8_t* data,
     }
 
     // make sure that the block actually ends with block total length
-    auto blockTotalLength = *(const uint32_t*)&data[idb.blockTotalLength - 4];
+    auto blockTotalLength = *(const uint32_t*)&data[idb.blockTotalLength - 4u];
     MMPR_ASSERT(idb.blockTotalLength == blockTotalLength);
 }
 
@@ -215,21 +215,21 @@ void PcapNgBlockParser::readEPB(const uint8_t* data, pcapng::EnhancedPacketBlock
     // packet data is padded to 32 bits, calculate the total size in memory (including
     // padding)
     auto packetDataTotalLength =
-        epb.capturePacketLength + (4 - epb.capturePacketLength % 4) % 4;
+        epb.capturePacketLength + (4u - epb.capturePacketLength % 4u) % 4u;
     // standard Enhanced Packet Block has size 32 (without packet data or options)
-    if (epb.blockTotalLength - 32 > packetDataTotalLength) {
-        uint32_t totalOptionsLength = epb.blockTotalLength - 32 - packetDataTotalLength;
+    if (epb.blockTotalLength - 32u > packetDataTotalLength) {
+        uint32_t totalOptionsLength = epb.blockTotalLength - 32u - packetDataTotalLength;
         uint32_t readOptionsLength = 0;
         while (readOptionsLength < totalOptionsLength) {
             pcapng::Option option{};
             PcapNgBlockOptionParser::readEPBOption(
-                data, option, 32 + packetDataTotalLength + readOptionsLength);
+                data, option, 32u + packetDataTotalLength + readOptionsLength);
             readOptionsLength += option.totalLength();
         }
     }
 
     // make sure that the block actually ends with block total length
-    auto blockTotalLength = *(const uint32_t*)&data[epb.blockTotalLength - 4];
+    auto blockTotalLength = *(const uint32_t*)&data[epb.blockTotalLength - 4u];
     MMPR_ASSERT(epb.blockTotalLength == blockTotalLength);
 }
 

--- a/src/pcapng/PcapNgReader.cpp
+++ b/src/pcapng/PcapNgReader.cpp
@@ -210,4 +210,8 @@ TraceInterface PcapNgReader<TReader>::getTraceInterface(size_t id) const {
     return mTraceInterfaces[id];
 }
 
+template class PcapNgReader<FReadFileReader>;
+template class PcapNgReader<MMapFileReader>;
+template class PcapNgReader<ZstdFileReader>;
+
 } // namespace mmpr

--- a/src/pcapng/PcapNgReader.cpp
+++ b/src/pcapng/PcapNgReader.cpp
@@ -11,7 +11,6 @@ PcapNgReader<TReader>::PcapNgReader(const std::string& filepath) : mReader(filep
         std::stringstream sstream;
         sstream << std::hex << magicNumber;
         std::string hex = sstream.str();
-        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error(
             "Expected PcapNG format to start with appropriate magic "
             "number, instead got: 0x" +
@@ -27,7 +26,6 @@ PcapNgReader<TReader>::PcapNgReader(TReader&& reader)
         std::stringstream sstream;
         sstream << std::hex << magicNumber;
         std::string hex = sstream.str();
-        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
         throw std::runtime_error(
             "Expected PcapNG format to start with appropriate magic "
             "number, instead got: 0x" +

--- a/src/pcapng/PcapNgReader.cpp
+++ b/src/pcapng/PcapNgReader.cpp
@@ -1,1 +1,215 @@
 #include "mmpr/pcapng/PcapNgReader.hpp"
+
+#include <sstream>
+
+namespace mmpr {
+
+template <typename TReader>
+PcapNgReader<TReader>::PcapNgReader(const std::string& filepath) : mReader(filepath) {
+    uint32_t magicNumber = *(uint32_t*)mReader.data();
+    if (magicNumber != PCAPNG) {
+        std::stringstream sstream;
+        sstream << std::hex << magicNumber;
+        std::string hex = sstream.str();
+        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
+        throw std::runtime_error(
+            "Expected PcapNG format to start with appropriate magic "
+            "number, instead got: 0x" +
+            hex + ", possibly little/big endian issue while reading file " + filepath);
+    }
+}
+
+template <typename TReader>
+PcapNgReader<TReader>::PcapNgReader(TReader&& reader)
+    : mReader(std::forward<TReader>(reader)) {
+    uint32_t magicNumber = *(uint32_t*)mReader.data();
+    if (magicNumber != PCAPNG) {
+        std::stringstream sstream;
+        sstream << std::hex << magicNumber;
+        std::string hex = sstream.str();
+        std::transform(hex.begin(), hex.end(), hex.begin(), ::toupper);
+        throw std::runtime_error(
+            "Expected PcapNG format to start with appropriate magic "
+            "number, instead got: 0x" +
+            hex + ", possibly little/big endian issue while reading file " +
+            getFilepath());
+    }
+}
+
+template <typename TReader>
+bool PcapNgReader<TReader>::isExhausted() const {
+    return mReader.isExhausted();
+}
+
+template <typename TReader>
+bool PcapNgReader<TReader>::readNextPacket(Packet& packet) {
+    if (isExhausted()) {
+        // nothing more to read
+        return false;
+    }
+
+    // make sure there are enough bytes to read
+    if (mReader.getSafeToReadSize() < 8) {
+        throw std::runtime_error("Expected to read at least one more block (8 bytes at "
+                                 "least), but there are only " +
+                                 std::to_string(mReader.getSafeToReadSize()) +
+                                 " bytes left in the file");
+    }
+
+    uint32_t blockType = *(uint32_t*)&mReader.data()[mReader.mOffset];
+    uint32_t blockTotalLength = *(uint32_t*)&mReader.data()[mReader.mOffset + 4];
+
+    // TODO add support for Simple Packet Blocks
+    while (blockType != MMPR_ENHANCED_PACKET_BLOCK && blockType != MMPR_PACKET_BLOCK) {
+        if (blockType == MMPR_SECTION_HEADER_BLOCK) {
+            pcapng::SectionHeaderBlock shb{};
+            PcapNgBlockParser::readSHB(&mReader.data()[mReader.mOffset], shb);
+            mMetadata.comment = shb.options.comment;
+            mMetadata.os = shb.options.os;
+            mMetadata.hardware = shb.options.hardware;
+            mMetadata.userApplication = shb.options.userApplication;
+        } else if (blockType == MMPR_INTERFACE_DESCRIPTION_BLOCK) {
+            pcapng::InterfaceDescriptionBlock idb{};
+            PcapNgBlockParser::readIDB(&mReader.data()[mReader.mOffset], idb);
+            mDataLinkType = idb.linkType;
+            mMetadata.timestampResolution = idb.options.timestampResolution;
+            mTraceInterfaces.emplace_back(idb.options.name, idb.options.description,
+                                          idb.options.filter, idb.options.os);
+        }
+
+        mReader.mOffset += blockTotalLength;
+
+        if (isExhausted()) {
+            // we have reached the end of the file
+            return false;
+        }
+
+        // make sure there are enough bytes to read
+        if (mReader.getSafeToReadSize() < 8) {
+            throw std::runtime_error(
+                "Expected to read at least one more block (8 bytes at "
+                "least), but there are only " +
+                std::to_string(mReader.getSafeToReadSize()) + " bytes left in the file");
+        }
+
+        // try to read next block type
+        blockType = *(const uint32_t*)&mReader.data()[mReader.mOffset];
+        blockTotalLength = *(const uint32_t*)&mReader.data()[mReader.mOffset + 4];
+    }
+
+    switch (blockType) {
+    case MMPR_ENHANCED_PACKET_BLOCK: {
+        pcapng::EnhancedPacketBlock epb{};
+        PcapNgBlockParser::readEPB(&mReader.data()[mReader.mOffset], epb);
+        util::calculateTimestamps(mMetadata.timestampResolution, epb.timestampHigh,
+                                  epb.timestampLow, &(packet.timestampSeconds),
+                                  &(packet.timestampMicroseconds));
+        packet.captureLength = epb.capturePacketLength;
+        packet.length = epb.originalPacketLength;
+        packet.data = epb.packetData;
+        packet.interfaceIndex = epb.interfaceId;
+
+        mReader.mOffset += epb.blockTotalLength;
+        break;
+    }
+    case MMPR_PACKET_BLOCK: {
+        pcapng::PacketBlock pb{};
+        PcapNgBlockParser::readPB(&mReader.data()[mReader.mOffset], pb);
+        util::calculateTimestamps(mMetadata.timestampResolution, pb.timestampHigh,
+                                  pb.timestampLow, &(packet.timestampSeconds),
+                                  &(packet.timestampMicroseconds));
+        packet.captureLength = pb.capturePacketLength;
+        packet.length = pb.originalPacketLength;
+        packet.data = pb.packetData;
+        packet.interfaceIndex = pb.interfaceId;
+
+        mReader.mOffset += pb.blockTotalLength;
+        break;
+    }
+    }
+
+    return true;
+}
+
+template <typename TReader>
+uint32_t PcapNgReader<TReader>::readBlock() {
+    const auto blockType = *(const uint32_t*)&mReader.data()[mReader.mOffset];
+    const auto blockTotalLength = *(const uint32_t*)&mReader.data()[mReader.mOffset + 4];
+
+    switch (blockType) {
+    case MMPR_SECTION_HEADER_BLOCK: {
+        pcapng::SectionHeaderBlock shb{};
+        PcapNgBlockParser::readSHB(&mReader.data()[mReader.mOffset], shb);
+        mMetadata.comment = shb.options.comment;
+        mMetadata.os = shb.options.os;
+        mMetadata.hardware = shb.options.hardware;
+        mMetadata.userApplication = shb.options.userApplication;
+        break;
+    }
+    case MMPR_INTERFACE_DESCRIPTION_BLOCK: {
+        pcapng::InterfaceDescriptionBlock idb{};
+        PcapNgBlockParser::readIDB(&mReader.data()[mReader.mOffset], idb);
+        mDataLinkType = idb.linkType;
+        mMetadata.timestampResolution = idb.options.timestampResolution;
+        mTraceInterfaces.emplace_back(idb.options.name, idb.options.description,
+                                      idb.options.filter, idb.options.os);
+        break;
+    }
+    case MMPR_ENHANCED_PACKET_BLOCK: {
+        pcapng::EnhancedPacketBlock epb{};
+        PcapNgBlockParser::readEPB(&mReader.data()[mReader.mOffset], epb);
+        break;
+    }
+    case MMPR_PACKET_BLOCK: {
+        // deprecated in newer versions of PcapNG
+        pcapng::PacketBlock pb{};
+        PcapNgBlockParser::readPB(&mReader.data()[mReader.mOffset], pb);
+        break;
+    }
+    case MMPR_SIMPLE_PACKET_BLOCK: {
+        MMPR_WARN("Parsing of Simple Packet Blocks not implemented, skipping\n");
+        break;
+    }
+    case MMPR_NAME_RESOLUTION_BLOCK: {
+        MMPR_WARN("Parsing of Name Resolution Blocks not implemented, skipping\n");
+        break;
+    }
+    case MMPR_INTERFACE_STATISTICS_BLOCK: {
+        pcapng::InterfaceStatisticsBlock isb{};
+        PcapNgBlockParser::readISB(&mReader.data()[mReader.mOffset], isb);
+        break;
+    }
+    case MMPR_DECRYPTION_SECRETS_BLOCK: {
+        MMPR_WARN("Parsing of Decryption Secrets Blocks not implemented, skipping\n");
+        break;
+    }
+    case MMPR_CUSTOM_CAN_COPY_BLOCK: {
+        MMPR_WARN("Parsing of Custom (Can Copy) Blocks not implemented, skipping\n");
+        break;
+    }
+    case MMPR_CUSTOM_DO_NOT_COPY_BLOCK: {
+        MMPR_WARN("Parsing of Custom (Do Not Copy) Blocks not implemented, skipping\n");
+        break;
+    }
+    default: {
+        MMPR_WARN_1("Encountered unknown block type: %u, skipping\n", blockType);
+        break;
+    }
+    }
+
+    // skip to next block
+    mReader.mOffset += (size_t)blockTotalLength;
+
+    return blockType;
+}
+
+template <typename TReader>
+TraceInterface PcapNgReader<TReader>::getTraceInterface(size_t id) const {
+    if (id >= mTraceInterfaces.size()) {
+        throw std::out_of_range("Trace interface index " + std::to_string(id) +
+                                " is out of range");
+    }
+    return mTraceInterfaces[id];
+}
+
+} // namespace mmpr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,8 +21,11 @@ add_executable(mmpr_test
     src/main.cpp
     src/testFileReader.cpp
 )
-target_compile_features(mmpr_test PRIVATE cxx_std_11)
-target_link_libraries(mmpr_test gtest_main mmpr::mmpr)
+target_link_libraries(mmpr_test
+    PUBLIC
+        mmpr::mmpr
+        gtest_main
+)
 
 add_test(NAME mmpr_test
     COMMAND mmpr_test

--- a/tests/src/modified_pcap/testMMModifiedPcapReader.cpp
+++ b/tests/src/modified_pcap/testMMModifiedPcapReader.cpp
@@ -13,7 +13,9 @@ TEST(MMModifiedPcapReader, ConstructorMissingFile) {
 }
 
 TEST(MMModifiedPcapReader, FaultyConstructor) {
+#ifdef __linux__ // throws un-catchable SEH exception on Windows
     EXPECT_THROW(mmpr::MMModifiedPcapReader{nullptr}, std::logic_error);
+#endif
     EXPECT_THROW(mmpr::MMModifiedPcapReader{""}, std::runtime_error);
 }
 

--- a/tests/src/pcap/testMMPcapReader.cpp
+++ b/tests/src/pcap/testMMPcapReader.cpp
@@ -13,7 +13,9 @@ TEST(MMPcapReader, ConstructorMissingFile) {
 }
 
 TEST(MMPcapReader, FaultyConstructor) {
+#ifdef __linux__ // throws un-catchable SEH exception on Windows
     EXPECT_THROW(mmpr::MMPcapReader{nullptr}, std::logic_error);
+#endif
     EXPECT_THROW(mmpr::MMPcapReader{""}, std::runtime_error);
 }
 

--- a/tests/src/pcapng/testMMPcapNgReader.cpp
+++ b/tests/src/pcapng/testMMPcapNgReader.cpp
@@ -13,6 +13,8 @@ TEST(MMPcapNgReader, ConstructorMissingFile) {
 }
 
 TEST(MMPcapNgReader, FaultyConstructor) {
+#ifdef __linux__ // throws un-catchable SEH exception on Windows
     EXPECT_THROW(mmpr::MMPcapNgReader{nullptr}, std::logic_error);
+#endif
     EXPECT_THROW(mmpr::MMPcapNgReader{""}, std::runtime_error);
 }


### PR DESCRIPTION
This branch moves definitions of functions etc. from headers to their .cpp files. Appears to have no impact on benchmarks.