### PR TITLE
bugfix/allocator-deallocator-missmatch : fixed

### DIFF
--- a/include/fpcap/filesystem/reading/ZstdFileReader.hpp
+++ b/include/fpcap/filesystem/reading/ZstdFileReader.hpp
@@ -17,7 +17,7 @@ public:
     const uint8_t* data() const override { return mDecompressedDataPtr; }
 
 private:
-    std::unique_ptr<uint8_t> mDecompressedData;
+    std::unique_ptr<uint8_t []> mDecompressedData;
     const uint8_t* mDecompressedDataPtr;
 };
 

--- a/src/filesystem/reading/ZstdFileReader.cpp
+++ b/src/filesystem/reading/ZstdFileReader.cpp
@@ -42,7 +42,7 @@ ZstdFileReader::ZstdFileReader(const std::string& filepath) : FileReader(filepat
         throw std::runtime_error("decompressed size unknown");
     }
 
-    mDecompressedData = std::unique_ptr<uint8_t>(new uint8_t[decompressedFileSize]);
+    mDecompressedData = std::unique_ptr<uint8_t []>(new uint8_t[decompressedFileSize]);
     if (!mDecompressedData) {
         throw std::runtime_error("Unable to malloc " +
                                  std::to_string(decompressedFileSize) +


### PR DESCRIPTION
Fixes an allocator-deallocator missmatch within the ZstdFileReader in which an array to store decompressed data in is allocated but stored in a unique pointer using the wrong deallocator.